### PR TITLE
#19838 FIX replace print error with event message when error on update line …

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -819,8 +819,7 @@ if (empty($reshook)) {
 		} else {
 			$db->rollback();
 
-			dol_print_error($db, $object->error);
-			exit;
+			setEventMessages($object->error, $object->errors, 'errors');
 		}
 	}
 


### PR DESCRIPTION
FIX replace print error with event message when error on update line in supplier order
- when you have an error on trigger for example you return -1 and you got an error page without messages