### PR TITLE
NEW allow a ticket to be automatically marked as read when created fr…

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -225,6 +225,13 @@ if (empty($reshook)) {
 					$object->add_contact($user->id, "SUPPORTTEC", 'internal');
 				}
 
+				// Auto mark as read if created from backend
+				if (!empty($conf->global->TICKET_AUTO_READ_WHEN_CREATED_FROM_BACKEND) && $user->rights->ticket->write) {
+					if ( ! $object->markAsRead($user) > 0) {
+						setEventMessages($object->error, $object->errors, 'errors');
+					}
+				}
+
 				// Auto assign contrat
 				$contractid = 0;
 				if (!empty($conf->global->TICKET_AUTO_ASSIGN_CONTRACT_CREATE)) {


### PR DESCRIPTION
When created by a user with write rights on tickets, the ticket should be automatically marked as read.

Introduces option TICKET_AUTO_READ_WHEN_CREATED_FROM_BACKEND to enable this feature.