### PR TITLE
Fix ticket module : security check prevents automatic fill. (19920)

### DIFF
--- a/htdocs/ticket/agenda.php
+++ b/htdocs/ticket/agenda.php
@@ -80,7 +80,6 @@ if (!$action) {
 
 // Security check
 $id = GETPOST("id", 'int');
-$socid = 0;
 if ($user->socid > 0) $socid = $user->socid;
 $result = restrictedArea($user, 'ticket', $id, '');
 

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -114,7 +114,6 @@ if ($id || $track_id || $ref) {
 $url_page_current = DOL_URL_ROOT.'/ticket/card.php';
 
 // Security check - Protection if external user
-$socid = 0;
 if ($user->socid > 0) $socid = $user->socid;
 $result = restrictedArea($user, 'ticket', $object->id);
 

--- a/htdocs/ticket/contact.php
+++ b/htdocs/ticket/contact.php
@@ -61,7 +61,6 @@ $permissiontoadd = $user->rights->ticket->write;
 
 // Security check
 $id = GETPOST("id", 'int');
-$socid = 0;
 if ($user->socid > 0) $socid = $user->socid;
 $result = restrictedArea($user, 'ticket', $object->id, '');
 

--- a/htdocs/ticket/messaging.php
+++ b/htdocs/ticket/messaging.php
@@ -80,7 +80,6 @@ $permissiontoadd = $user->rights->ticket->write;
 
 // Security check
 $id = GETPOST("id", 'int');
-$socid = 0;
 if ($user->socid > 0) $socid = $user->socid;
 $result = restrictedArea($user, 'ticket', $object->id, '');
 


### PR DESCRIPTION
When creating a ticket from a thirdparty card, the security check would break the autofill of thirdparty information.

This is due to "$socid = 0" in security check, that resets the $socid acquired throught GETPOST().

I don't understand how this "$socid = 0" brings security. I suggest to remove it from other similar files.

screenshots:

When creating a ticket from thirdparty card...
![create_ticket_from_tier](https://user-images.githubusercontent.com/89838020/150967311-53d0c63d-224c-4d2f-94c5-1eb374dfecbb.png)

... Thirdparty info is not filled ...
![create_ticket_tier not_filled](https://user-images.githubusercontent.com/89838020/150967422-cc65cf0a-6e83-4ba1-b8eb-9188f1574c0e.png)

... If we remove $socid = 0, thirdparty info is filled.
![create_ticket_with_tier_filled](https://user-images.githubusercontent.com/89838020/150967470-d9098176-5846-446d-8c96-e022abed0a86.png)