### PR TITLE
 fix : restrict external user ticket list view (19922)

### DIFF
--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -157,6 +157,8 @@ $arrayfields = dol_sort_array($arrayfields, 'position');
 if (!$user->rights->ticket->read) {
 	accessforbidden();
 }
+// restrict view to current user's company
+if ($user->socid > 0) $socid = $user->socid;
 
 // Store current page url
 $url_page_current = dol_buildpath('/ticket/list.php', 1);


### PR DESCRIPTION
When connected as an external user with view rights on tickets, one could see the whole ticket list.

This restricts the list view to only the external user's company.