### PR TITLE
new : allow informations to be displayed before the public ticket list (19928)

### DIFF
--- a/htdocs/public/ticket/list.php
+++ b/htdocs/public/ticket/list.php
@@ -70,8 +70,8 @@ if (isset($_SESSION['email_customer'])) {
 
 $object = new Ticket($db);
 
-
-
+// Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
+$hookmanager->initHooks(array('ticketpubliclist', 'globalcard'));
 
 /*
  * Actions
@@ -397,6 +397,11 @@ if ($action == "view_ticketlist") {
 
 				$varpage = empty($contextpage) ? $url_page_current : $contextpage;
 				$selectedfields = $form->multiSelectArrayWithCheckbox('selectedfields', $arrayfields, $varpage); // This also change content of $arrayfields
+
+				// allow to display information before list
+				$parameters=array('arrayfields'=>$arrayfields);
+				$reshook=$hookmanager->executeHooks('printFieldListHeader', $parameters, $object, $action);    // Note that $action and $object may have been modified by hook
+				print $hookmanager->resPrint;
 
 				print '<table class="liste '.($moreforfilter ? "listwithfilterbefore" : "").'">';
 


### PR DESCRIPTION
Add a hook before the public ticket list to allow the display of complementary information such as consumed tickets.