### PR TITLE
2022.5 NEW : optional display status warning on ticket list

### DIFF
--- a/htdocs/admin/ticket.php
+++ b/htdocs/admin/ticket.php
@@ -181,6 +181,18 @@ if ($action == 'setvarother') {
 	if (!($res > 0)) {
 		$error++;
 	}
+
+	$param_delay_first_response = GETPOST('delay_first_response', 'int');
+	$res = dolibarr_set_const($db, 'TICKET_DELAY_BEFORE_FIRST_RESPONSE', $param_delay_first_response, 'chaine', 0, '', $conf->entity);
+	if (!($res > 0)) {
+		$error++;
+	}
+
+	$param_delay_between_responses = GETPOST('delay_between_responses', 'int');
+	$res = dolibarr_set_const($db, 'TICKET_DELAY_SINCE_LAST_RESPONSE', $param_delay_between_responses, 'chaine', 0, '', $conf->entity);
+	if (!($res > 0)) {
+		$error++;
+	}
 }
 
 
@@ -478,7 +490,8 @@ print '<td></td>';
 print "</tr>\n";
 
 // Auto assign ticket at user who created it
-print '<tr class="oddeven"><td>'.$langs->trans("TicketsAutoAssignTicket").'</td>';
+print '<tr class="oddeven">';
+print '<td>'.$langs->trans("TicketsAutoAssignTicket").'</td>';
 print '<td class="left">';
 if ($conf->use_javascript_ajax) {
 	print ajax_constantonoff('TICKET_AUTO_ASSIGN_USER_CREATE');
@@ -492,11 +505,40 @@ print $form->textwithpicto('', $langs->trans("TicketsAutoAssignTicketHelp"), 1, 
 print '</td>';
 print '</tr>';
 
-print '</table><br>';
-
 if (!$conf->use_javascript_ajax) {
 	print '</form>';
 }
+
+// Define wanted maximum time elapsed before answers to tickets
+print '<form method="post" action="'.$_SERVER['PHP_SELF'].'" enctype="multipart/form-data" >';
+print '<input type="hidden" name="action" value="setvarother">';
+
+print '<tr class="oddeven">';
+print '<td>'.$langs->trans("TicketsDelayBeforeFirstAnswer")."</td>";
+print '<td class="left">
+	<input type="number" value="'.$conf->global->TICKET_DELAY_BEFORE_FIRST_RESPONSE.'" name="delay_first_response">
+	<input type="submit" class="button small" value="'.$langs->trans("Save").'">
+	</td>';
+print '<td class="center">';
+print $form->textwithpicto('', $langs->trans("TicketsDelayBeforeFirstAnswerHelp"), 1, 'help');
+print '</td>';
+print '</tr>';
+
+print '<tr class="oddeven">';
+print '<td>'.$langs->trans("TicketsDelayBetweenAnswers")."</td>";
+print '<td class="left">
+	<input type="number" value="'.$conf->global->TICKET_DELAY_SINCE_LAST_RESPONSE.'" name="delay_between_responses">
+	<input type="submit" class="button small" value="'.$langs->trans("Save").'">
+	</td>';
+print '<td class="center">';
+print $form->textwithpicto('', $langs->trans("TicketsDelayBetweenAnswersHelp"), 1, 'help');
+print '</td>';
+print '</tr>';
+
+print '</form>';
+
+print '</table><br>';
+
 
 // Admin var of module
 print load_fiche_titre($langs->trans("Notification"), '', '');

--- a/htdocs/core/lib/ticket.lib.php
+++ b/htdocs/core/lib/ticket.lib.php
@@ -476,7 +476,7 @@ function show_ticket_messaging($conf, $langs, $db, $filterobj, $objcon = '', $no
 	if ($sql) {	// May not be defined if module Agenda is not enabled and mailing module disabled too
 		$sql .= $db->order($sortfield_new, $sortorder);
 
-		dol_syslog("company.lib::show_actions_done", LOG_DEBUG);
+		dol_syslog("ticket.lib::show_ticket_messaging", LOG_DEBUG);
 		$resql = $db->query($sql);
 		if ($resql) {
 			$i = 0;
@@ -491,7 +491,7 @@ function show_ticket_messaging($conf, $langs, $db, $filterobj, $objcon = '', $no
 					$result = $contactaction->fetchResources();
 					if ($result < 0) {
 						dol_print_error($db);
-						setEventMessage("company.lib::show_actions_done Error fetch ressource", 'errors');
+						setEventMessage("ticket.lib::show_ticket_messaging Error fetch ressource", 'errors');
 					}
 
 					//if ($donetodo == 'todo') $sql.= " AND ((a.percent >= 0 AND a.percent < 100) OR (a.percent = -1 AND a.datep > '".$db->idate($now)."'))";

--- a/htdocs/core/modules/modTicket.class.php
+++ b/htdocs/core/modules/modTicket.class.php
@@ -106,7 +106,9 @@ class modTicket extends DolibarrModules
 		$this->const = array(
 			1 => array('TICKET_ENABLE_PUBLIC_INTERFACE', 'chaine', '0', 'Enable ticket public interface', 0),
 			2 => array('TICKET_ADDON', 'chaine', 'mod_ticket_simple', 'Ticket ref module', 0),
-			3 => array('TICKET_ADDON_PDF_ODT_PATH', 'chaine', 'DOL_DATA_ROOT/doctemplates/tickets', 'Ticket templates ODT/ODS directory for templates', 0)
+			3 => array('TICKET_ADDON_PDF_ODT_PATH', 'chaine', 'DOL_DATA_ROOT/doctemplates/tickets', 'Ticket templates ODT/ODS directory for templates', 0),
+			4 => array('TICKET_DELAY_BEFORE_FIRST_RESPONSE', 'chaine', '0', 'Maximum wanted elapsed time before a first answer to a ticket (in hours). Display a warning in tickets list if not respected.', 1),
+			5 => array('TICKET_DELAY_SINCE_LAST_RESPONSE', 'chaine', '0', 'Maximum wanted elapsed time between two answers on the same ticket (in hours). Display a warning in tickets list if not respected.', 1)
 		);
 
 

--- a/htdocs/core/modules/modTicket.class.php
+++ b/htdocs/core/modules/modTicket.class.php
@@ -107,8 +107,8 @@ class modTicket extends DolibarrModules
 			1 => array('TICKET_ENABLE_PUBLIC_INTERFACE', 'chaine', '0', 'Enable ticket public interface', 0),
 			2 => array('TICKET_ADDON', 'chaine', 'mod_ticket_simple', 'Ticket ref module', 0),
 			3 => array('TICKET_ADDON_PDF_ODT_PATH', 'chaine', 'DOL_DATA_ROOT/doctemplates/tickets', 'Ticket templates ODT/ODS directory for templates', 0),
-			4 => array('TICKET_DELAY_BEFORE_FIRST_RESPONSE', 'chaine', '0', 'Maximum wanted elapsed time before a first answer to a ticket (in hours). Display a warning in tickets list if not respected.', 1),
-			5 => array('TICKET_DELAY_SINCE_LAST_RESPONSE', 'chaine', '0', 'Maximum wanted elapsed time between two answers on the same ticket (in hours). Display a warning in tickets list if not respected.', 1)
+			4 => array('TICKET_DELAY_BEFORE_FIRST_RESPONSE', 'chaine', '0', 'Maximum wanted elapsed time before a first answer to a ticket (in hours). Display a warning in tickets list if not respected.', 0),
+			5 => array('TICKET_DELAY_SINCE_LAST_RESPONSE', 'chaine', '0', 'Maximum wanted elapsed time between two answers on the same ticket (in hours). Display a warning in tickets list if not respected.', 0)
 		);
 
 

--- a/htdocs/langs/en_US/ticket.lang
+++ b/htdocs/langs/en_US/ticket.lang
@@ -134,6 +134,11 @@ TicketsPublicNotificationNewMessage=Send email(s) when a new message/comment is 
 TicketsPublicNotificationNewMessageHelp=Send email(s) when a new message is added from public interface (to assigned user or the notifications email to (update) and/or the notifications email to)
 TicketPublicNotificationNewMessageDefaultEmail=Notifications email to (update)
 TicketPublicNotificationNewMessageDefaultEmailHelp=Send an email to this address for each new message notifications if the ticket doesn't have a user assigned to it or if the user doesn't have any known email.
+TicketsDelayBeforeFirstAnswer=Time period after ticket opening before displaying a warning
+TicketsDelayBeforeFirstAnswerHelp=Time in hours. If a ticket did not receive an answer after this time period, a red warning icon will be displayed in the list view.
+TicketsDelayBetweenAnswers=Time period after an answer before displaying a warning
+TicketsDelayBetweenAnswersHelp= Time in hours. If a ticket that has been answered has not had further interaction after this time period, a black warning icon will be displayed in the list view.
+
 #
 # Index & list page
 #

--- a/htdocs/langs/en_US/ticket.lang
+++ b/htdocs/langs/en_US/ticket.lang
@@ -239,6 +239,8 @@ TicketNotNotifyTiersAtCreate=Not notify company at create
 Unread=Unread
 TicketNotCreatedFromPublicInterface=Not available. Ticket was not created from public interface.
 ErrorTicketRefRequired=Ticket reference name is required
+TicketsDelayForFirstResponseTooLong=Too much time elapsed since ticket opening without any answer.
+TicketsDelayFromLastResponseTooLong=Too much time elapsed since last answer on this ticket.
 
 #
 # Logs

--- a/htdocs/langs/fr_FR/ticket.lang
+++ b/htdocs/langs/fr_FR/ticket.lang
@@ -241,6 +241,8 @@ TicketNotNotifyTiersAtCreate=Ne pas notifier l'entreprise à la création
 Unread=Non lu
 TicketNotCreatedFromPublicInterface=Non disponible. Le ticket n’a pas été créé à partir de l'interface publique.
 ErrorTicketRefRequired=La référence du ticket est requise
+TicketsDelayForFirstResponseTooLong=Trop de temps écoulé sans réponse depuis l'ouverture du ticket.
+TicketsDelayFromLastResponseTooLong=Trop de temps écoulé depuis la dernière réponse sur ce ticket.
 
 #
 # Logs

--- a/htdocs/langs/fr_FR/ticket.lang
+++ b/htdocs/langs/fr_FR/ticket.lang
@@ -136,6 +136,11 @@ TicketsPublicNotificationNewMessage=Envoyer un ou des emails lorsqu’un nouveau
 TicketsPublicNotificationNewMessageHelp=Envoyer un (des) courriel(s) lorsqu’un nouveau message est ajouté à partir de l’interface publique (à l’utilisateur désigné ou au courriel de notification  (mise à jour) et/ou au courriel de notification)
 TicketPublicNotificationNewMessageDefaultEmail=Emails de notifications à (mise à jour)
 TicketPublicNotificationNewMessageDefaultEmailHelp=Envoyez un email à cette adresse email pour chaque nouveau message de notifications si le ticket n'a pas d'utilisateur assigné ou si l'utilisateur n'a pas d'email connu.
+TicketsDelayBeforeFirstAnswer=Délai de réponse avant d'afficher une icône d' avertissement
+TicketsDelayBeforeFirstAnswerHelp= Temps en heures. Si un ticket n'a reçu aucune réponse après ce délai, une icône rouge est affichée dans la vue en liste.
+TicketsDelayBetweenAnswers=Délai entre deux réponses avant d'afficher une icône d' avertissement
+TicketsDelayBetweenAnswersHelp= Temps en heures. Si un ticket auquel on a répondu n'a aucune réponse suivante après ce délai, une icône noire est affichée dans la vue en liste.
+
 #
 # Index & list page
 #

--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -1012,7 +1012,7 @@ while ($i < min($num, $limit)) {
 			} elseif (in_array($val['type'], array('date', 'datetime', 'timestamp'))) {
 				print $object->showOutputField($val, $key, $db->jdate($obj->$key), '');
 			} elseif ($key == 'ref'){
-				print $object->showOutputField($val, $key, $obj->$key, '');
+				print $object->showOutputField($val, $key, $obj->$key, '') ;
 
 				// display a warning on untreated tickets
 				$is_open = ($object->fk_statut['index'] != Ticket::STATUS_CLOSED && $object->fk_statut['index'] != Ticket::STATUS_CANCELED );
@@ -1022,14 +1022,14 @@ while ($i < min($num, $limit)) {
 					$last_msg_date =  $db->jdate($obj->last_msg_date);
 					$hour_diff = ($now - $last_msg_date) / 3600 ;
 
-					if (!empty($conf->global->TICKET_DELAY_BEFORE_FIRST_RESPONSE && $last_msg_date == 0)){
+					if (!empty($conf->global->TICKET_DELAY_BEFORE_FIRST_RESPONSE && $last_msg_date == 0)) {
 						$creation_date =  $db->jdate($obj->datec);
 						$hour_diff_creation = ($now - $creation_date) / 3600 ;
 						if ($hour_diff_creation > $conf->global->TICKET_DELAY_BEFORE_FIRST_RESPONSE) {
 							print " " . img_picto($langs->trans('Late') . ' : ' . $langs->trans('TicketsDelayForFirstResponseTooLong', $conf->global->TICKET_DELAY_BEFORE_FIRST_RESPONSE), 'warning', 'style="color: red;"', false, 0, 0, '', '');
 						}
-					} 
-					else if (!empty($conf->global->TICKET_DELAY_SINCE_LAST_RESPONSE) && $hour_diff > $conf->global->TICKET_DELAY_SINCE_LAST_RESPONSE) {
+					}
+					elseif (!empty($conf->global->TICKET_DELAY_SINCE_LAST_RESPONSE) && $hour_diff > $conf->global->TICKET_DELAY_SINCE_LAST_RESPONSE) {
 						print " " . img_picto($langs->trans('Late') . ' : ' . $langs->trans('TicketsDelayFromLastResponseTooLong', $conf->global->TICKET_DELAY_SINCE_LAST_RESPONSE), 'warning');
 					}
 				}

--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -1016,7 +1016,7 @@ while ($i < min($num, $limit)) {
 
 				// display a warning on untreated tickets
 				$is_open = ($object->fk_statut['index'] != Ticket::STATUS_CLOSED && $object->fk_statut['index'] != Ticket::STATUS_CANCELED );
-				$should_show_warning = (!empty($conf->global->TICKET_DELAY_FROM_LAST_RESPONSE) || !empty($conf->global->TICKET_DELAY_BEFORE_FIRST_RESPONSE));
+				$should_show_warning = (!empty($conf->global->TICKET_DELAY_SINCE_LAST_RESPONSE) || !empty($conf->global->TICKET_DELAY_BEFORE_FIRST_RESPONSE));
 				if ($is_open && $should_show_warning) {
 					$now = dol_now();
 					$last_msg_date =  $db->jdate($obj->last_msg_date);
@@ -1026,11 +1026,11 @@ while ($i < min($num, $limit)) {
 						$creation_date =  $db->jdate($obj->datec);
 						$hour_diff_creation = ($now - $creation_date) / 3600 ;
 						if ($hour_diff_creation > $conf->global->TICKET_DELAY_BEFORE_FIRST_RESPONSE) {
-							print " " . img_picto($langs->trans('Late') . ' : ' . $langs->trans('TicketsDelayForFirstResponseTooLong', $conf->global->TICKET_DELAY_FOR_FIRST_RESPONSE), 'warning', 'style="color: red;"', false, 0, 0, '', '');
+							print " " . img_picto($langs->trans('Late') . ' : ' . $langs->trans('TicketsDelayForFirstResponseTooLong', $conf->global->TICKET_DELAY_BEFORE_FIRST_RESPONSE), 'warning', 'style="color: red;"', false, 0, 0, '', '');
 						}
 					} 
-					else if (!empty($conf->global->TICKET_DELAY_FROM_LAST_RESPONSE) && $hour_diff > $conf->global->TICKET_DELAY_FROM_LAST_RESPONSE) {
-						print " " . img_picto($langs->trans('Late') . ' : ' . $langs->trans('TicketsDelayFromLastResponseTooLong', $conf->global->TICKET_DELAY_FROM_LAST_RESPONSE), 'warning');
+					else if (!empty($conf->global->TICKET_DELAY_SINCE_LAST_RESPONSE) && $hour_diff > $conf->global->TICKET_DELAY_SINCE_LAST_RESPONSE) {
+						print " " . img_picto($langs->trans('Late') . ' : ' . $langs->trans('TicketsDelayFromLastResponseTooLong', $conf->global->TICKET_DELAY_SINCE_LAST_RESPONSE), 'warning');
 					}
 				}
 			} else {	// Example: key=fk_soc, obj->key=123 val=array('type'=>'integer', ...


### PR DESCRIPTION
Optionnaly displays warnings on ticket list when delays are configured.

Introduces two new options : 
- TICKET_DELAY_BEFORE_FIRST_RESPONSE : tickets should be answered before this delay (hours)
- TICKET_DELAY_SINCE_LAST_RESPONSE : when answered, tickets should have another answer before this delay (hours).
