### PR TITLE
2022.5 fix ticket return list db error syntax ( #20089)

### DIFF
--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -393,7 +393,7 @@ foreach ($search as $key => $val) {
 		continue;
 	}
 	$mode_search = (($object->isInt($object->fields[$key]) || $object->isFloat($object->fields[$key])) ? 1 : 0);
-	if ($search[$key] != '') {
+	if ($search[$key] != '' && !empty($val)) {
 		$sql .= natural_search($key, $search[$key], $mode_search);
 	}
 }
@@ -611,9 +611,9 @@ if ($limit > 0 && $limit != $conf->liste_limit) {
 	$param .= '&limit='.urlencode($limit);
 }
 foreach ($search as $key => $val) {
-	if (is_array($search[$key]) && count($search[$key])) {
-		foreach ($search[$key] as $skey) {
-			$param .= '&search_'.$key.'[]='.urlencode($skey);
+	if (is_array($val) && count($val)) {
+		foreach ($val as $skey) {
+			$param .= (!empty($val)) ? '&search_'.$key.'[]='.urlencode($skey) : "";
 		}
 	} else {
 		$param .= '&search_'.$key.'='.urlencode($search[$key]);

--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -393,7 +393,7 @@ foreach ($search as $key => $val) {
 		continue;
 	}
 	$mode_search = (($object->isInt($object->fields[$key]) || $object->isFloat($object->fields[$key])) ? 1 : 0);
-	if ($search[$key] != '' && !empty($val)) {
+	if ($search[$key] != '' && !is_array($val)) {
 		$sql .= natural_search($key, $search[$key], $mode_search);
 	}
 }


### PR DESCRIPTION
When going to a ticket from a thirdparty; **then** clicking "return list", one would get a DB error.

