### PR TITLE
fix ticket automatic email (#20094)

### DIFF
--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -249,7 +249,7 @@ if (empty($reshook) && $action == 'create_ticket' && GETPOST('add', 'alpha')) {
 				$message  = ($conf->global->TICKET_MESSAGE_MAIL_NEW ? $conf->global->TICKET_MESSAGE_MAIL_NEW : $langs->transnoentities('TicketNewEmailBody')).'<br><br>';
 				$message .= $langs->transnoentities('TicketNewEmailBodyInfosTicket').'<br>';
 
-				$url_public_ticket = ($conf->global->TICKET_URL_PUBLIC_INTERFACE ? $conf->global->TICKET_URL_PUBLIC_INTERFACE.'/' : dol_buildpath('/public/ticket/view.php', 2)).'?track_id='.$object->track_id;
+				$url_public_ticket = ($conf->global->TICKET_URL_PUBLIC_INTERFACE ? $conf->global->TICKET_URL_PUBLIC_INTERFACE : dol_buildpath('/public/ticket', 2)).'/view.php?track_id='.$object->track_id;
 				$infos_new_ticket = $langs->transnoentities('TicketNewEmailBodyInfosTrackId', '<a href="'.$url_public_ticket.'" rel="nofollow noopener">'.$object->track_id.'</a>').'<br>';
 				$infos_new_ticket .= $langs->transnoentities('TicketNewEmailBodyInfosTrackUrl').'<br><br>';
 


### PR DESCRIPTION
When sending an email to the customer,
If a custom URL had been provided for ticket public interface,
the link provided in the email did lead to the index of the public interface.
We want it to lead to /view.php

example of current behavior:

-    my public ticket interface has a custom URL https://custom.dolibarr.fr/
-    A customer creates a ticket
-    A confirmation email is sent to them
-    This email contains a link to the ticket that leads to https://custom.dolibarr.fr/?track_id=<track_id>

Expected behavior :

-    I want this link to lead to the view page : https://custom.dolibarr.fr/view.php?track_id=<track_id>