### PR TITLE
fix bookmarks info bubble (#20178)

### DIFF
--- a/htdocs/bookmarks/bookmarks.lib.php
+++ b/htdocs/bookmarks/bookmarks.lib.php
@@ -66,7 +66,7 @@ function printDropdownBookmarksList()
 
 
 	// Url to list bookmark
-	$listbtn = '<a class="top-menu-dropdown-link" title="'.$langs->trans('AddThisPageToBookmarks').'" href="'.DOL_URL_ROOT.'/bookmarks/list.php" >';
+	$listbtn = '<a class="top-menu-dropdown-link" title="'.$langs->trans('ListOfBookmarks').'" href="'.DOL_URL_ROOT.'/bookmarks/list.php" >';
 	$listbtn .= img_picto('', 'bookmark', 'class="paddingright"').$langs->trans('Bookmarks').'</a>';
 
 	// Url to go on create new bookmark page


### PR DESCRIPTION
This fixes the link to translation string for bookmark info bubble.

The string was wrong : 

![bookmarks](https://user-images.githubusercontent.com/89838020/155535466-44ca4155-f128-4e76-a238-3a2883e80530.png)