### PR TITLE
2022.5 notify ticket close (PR #20222)

### DIFF
--- a/htdocs/admin/ticket.php
+++ b/htdocs/admin/ticket.php
@@ -181,6 +181,12 @@ if ($action == 'setvarother') {
 	if (!($res > 0)) {
 		$error++;
 	}
+
+	$param_auto_notify_close = GETPOST('TICKET_NOTIFY_AT_CLOSING', 'alpha');
+	$res = dolibarr_set_const($db, 'TICKET_NOTIFY_AT_CLOSING', $param_auto_notify_close, 'chaine', 0, '', $conf->entity);
+	if (!($res > 0)) {
+		$error++;
+	}
 }
 
 
@@ -489,6 +495,21 @@ if ($conf->use_javascript_ajax) {
 print '</td>';
 print '<td class="center">';
 print $form->textwithpicto('', $langs->trans("TicketsAutoAssignTicketHelp"), 1, 'help');
+print '</td>';
+print '</tr>';
+
+// Auto notify contacts when closing the ticket
+print '<tr class="oddeven"><td>'.$langs->trans("TicketsAutoNotifyClose").'</td>';
+print '<td class="left">';
+if ($conf->use_javascript_ajax) {
+	print ajax_constantonoff('TICKET_NOTIFY_AT_CLOSING');
+} else {
+	$arrval = array('0' => $langs->trans("No"), '1' => $langs->trans("Yes"));
+	print $form->selectarray("TICKET_NOTIFY_AT_CLOSING", $arrval, $conf->global->TICKET_NOTIFY_AT_CLOSING);
+}
+print '</td>';
+print '<td class="center">';
+print $form->textwithpicto('', $langs->trans("TicketsAutoNotifyCloseHelp"), 1, 'help');
 print '</td>';
 print '</tr>';
 

--- a/htdocs/core/modules/modTicket.class.php
+++ b/htdocs/core/modules/modTicket.class.php
@@ -106,7 +106,8 @@ class modTicket extends DolibarrModules
 		$this->const = array(
 			1 => array('TICKET_ENABLE_PUBLIC_INTERFACE', 'chaine', '0', 'Enable ticket public interface', 0),
 			2 => array('TICKET_ADDON', 'chaine', 'mod_ticket_simple', 'Ticket ref module', 0),
-			3 => array('TICKET_ADDON_PDF_ODT_PATH', 'chaine', 'DOL_DATA_ROOT/doctemplates/tickets', 'Ticket templates ODT/ODS directory for templates', 0)
+			3 => array('TICKET_ADDON_PDF_ODT_PATH', 'chaine', 'DOL_DATA_ROOT/doctemplates/tickets', 'Ticket templates ODT/ODS directory for templates', 0),
+			2 => array('TICKET_NOTIFY_AT_CLOSING', 'chaine', '0', 'Automatically notify contacts when closing a module', 0),
 		);
 
 

--- a/htdocs/core/triggers/interface_50_modTicket_TicketEmail.class.php
+++ b/htdocs/core/triggers/interface_50_modTicket_TicketEmail.class.php
@@ -133,71 +133,21 @@ class InterfaceTicketEmail extends DolibarrTriggers
 
 				$langs->load('ticket');
 
+				$subject_admin = 'TicketNewEmailSubjectAdmin';
+				$body_admin = 'TicketNewEmailBodyAdmin';
+				$subject_customer = 'TicketNewEmailSubjectCustomer';
+				$body_customer = 'TicketNewEmailBodyCustomer';
+				$see_ticket_customer = 'TicketNewEmailBodyInfosTrackUrlCustomer';
+
 				// Send email to notification email
 				if (!empty($conf->global->TICKET_NOTIFICATION_EMAIL_TO) && empty($object->context['disableticketemail'])) {
 					$sendto = empty($conf->global->TICKET_NOTIFICATION_EMAIL_TO) ? '' : $conf->global->TICKET_NOTIFICATION_EMAIL_TO;
-
 					if ($sendto) {
-						// Init to avoid errors
-						$filepath = array();
-						$filename = array();
-						$mimetype = array();
-
-						/* Send email to admin */
-						$subject = '['.$conf->global->MAIN_INFO_SOCIETE_NOM.'] '.$langs->transnoentities('TicketNewEmailSubjectAdmin');
-						$message_admin = $langs->transnoentities('TicketNewEmailBodyAdmin', $object->track_id).'<br><br>';
-						$message_admin .= '<ul><li>'.$langs->trans('Title').' : '.$object->subject.'</li>';
-						$message_admin .= '<li>'.$langs->trans('Type').' : '.$langs->getLabelFromKey($this->db, 'TicketTypeShort'.$object->type_code, 'c_ticket_type', 'code', 'label', $object->type_code).'</li>';
-						$message_admin .= '<li>'.$langs->trans('Category').' : '.$langs->getLabelFromKey($this->db, 'TicketCategoryShort'.$object->category_code, 'c_ticket_category', 'code', 'label', $object->category_code).'</li>';
-						$message_admin .= '<li>'.$langs->trans('Severity').' : '.$langs->getLabelFromKey($this->db, 'TicketSeverityShort'.$object->severity_code, 'c_ticket_severity', 'code', 'label', $object->severity_code).'</li>';
-						$message_admin .= '<li>'.$langs->trans('From').' : '.($object->email_from ? $object->email_from : ($object->fk_user_create > 0 ? $langs->trans('Internal') : '')).'</li>';
-						// Extrafields
-						$extraFields = new ExtraFields($this->db);
-						$extraFields->fetch_name_optionals_label($object->table_element);
-						if (is_array($object->array_options) && count($object->array_options) > 0) {
-							foreach ($object->array_options as $key => $value) {
-								$key = substr($key, 8); // remove "options_"
-								$message_admin .= '<li>'.$langs->trans($extraFields->attributes[$object->element]['label'][$key]).' : '.$extraFields->showOutputField($key, $value).'</li>';
-							}
-						}
-						$message_admin .= '</ul>';
-
-						if ($object->fk_soc > 0) {
-								  $object->fetch_thirdparty();
-								  $message_admin .= '<p>'.$langs->trans('Company').' : '.$object->thirdparty->name.'</p>';
-						}
-
-						$message = $object->message;
-						if (!dol_textishtml($message)) {
-							$message = dol_nl2br($message);
-						}
-						$message_admin .= '<p>'.$langs->trans('Message').' : <br>'.$message.'</p>';
-						$message_admin .= '<p><a href="'.dol_buildpath('/ticket/card.php', 2).'?track_id='.$object->track_id.'">'.$langs->trans('SeeThisTicketIntomanagementInterface').'</a></p>';
-
-						$from = $conf->global->MAIN_INFO_SOCIETE_NOM.'<'.$conf->global->TICKET_NOTIFICATION_EMAIL_FROM.'>';
-						$replyto = $from;
-
-						$trackid = 'tic'.$object->id;
-
-						if (!empty($conf->global->TICKET_DISABLE_MAIL_AUTOCOPY_TO)) {
-							$old_MAIN_MAIL_AUTOCOPY_TO = $conf->global->MAIN_MAIL_AUTOCOPY_TO;
-							$conf->global->MAIN_MAIL_AUTOCOPY_TO = '';
-						}
-						include_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
-						$mailfile = new CMailFile($subject, $sendto, $from, $message_admin, $filepath, $mimetype, $filename, '', '', 0, -1, '', '', $trackid, '', 'ticket');
-						if ($mailfile->error) {
-							dol_syslog($mailfile->error, LOG_DEBUG);
-						} else {
-								 $result = $mailfile->sendfile();
-						}
-						if (!empty($conf->global->TICKET_DISABLE_MAIL_AUTOCOPY_TO)) {
-							$conf->global->MAIN_MAIL_AUTOCOPY_TO = $old_MAIN_MAIL_AUTOCOPY_TO;
-						}
+						$this->ComposeAndSendAdminMessage($sendto, $subject_admin, $body_admin, $object, $langs, $conf);
 					}
 				}
 
 				// Send email to customer
-
 				if (empty($conf->global->TICKET_DISABLE_CUSTOMER_MAILS) && empty($object->context['disableticketemail']) && $object->notify_tiers_at_create) {
 					$sendto = '';
 
@@ -218,72 +168,7 @@ class InterfaceTicketEmail extends DolibarrTriggers
 					}
 
 					if ($sendto) {
-						// Init to avoid errors
-						$filepath = array();
-						$filename = array();
-						$mimetype = array();
-
-						$subject = '['.$conf->global->MAIN_INFO_SOCIETE_NOM.'] '.$langs->transnoentities('TicketNewEmailSubjectCustomer');
-						$message_customer = $langs->transnoentities('TicketNewEmailBodyCustomer', $object->track_id).'<br><br>';
-						$message_customer .= '<ul><li>'.$langs->trans('Title').' : '.$object->subject.'</li>';
-						$message_customer .= '<li>'.$langs->trans('Type').' : '.$langs->getLabelFromKey($this->db, 'TicketTypeShort'.$object->type_code, 'c_ticket_type', 'code', 'label', $object->type_code).'</li>';
-						$message_customer .= '<li>'.$langs->trans('Category').' : '.$langs->getLabelFromKey($this->db, 'TicketCategoryShort'.$object->category_code, 'c_ticket_category', 'code', 'label', $object->category_code).'</li>';
-						$message_customer .= '<li>'.$langs->trans('Severity').' : '.$langs->getLabelFromKey($this->db, 'TicketSeverityShort'.$object->severity_code, 'c_ticket_severity', 'code', 'label', $object->severity_code).'</li>';
-
-						// Extrafields
-						foreach ($this->attributes[$object->table_element]['label'] as $key => $value) {
-							$enabled = 1;
-							if ($enabled && isset($this->attributes[$object->table_element]['list'][$key])) {
-								$enabled = dol_eval($this->attributes[$object->table_element]['list'][$key], 1);
-							}
-							$perms = 1;
-							if ($perms && isset($this->attributes[$object->table_element]['perms'][$key])) {
-								$perms = dol_eval($this->attributes[$object->table_element]['perms'][$key], 1);
-							}
-
-							$qualified = true;
-							if (empty($enabled)) {
-								$qualified = false;
-							}
-							if (empty($perms)) {
-								$qualified = false;
-							}
-
-							if ($qualified) {
-								$message_customer .= '<li>'.$langs->trans($key).' : '.$value.'</li>';
-							}
-						}
-
-						$message_customer .= '</ul>';
-
-						$message = $object->message;
-						if (!dol_textishtml($message)) {
-							$message = dol_nl2br($message);
-						}
-						$message_customer .= '<p>'.$langs->trans('Message').' : <br>'.$message.'</p>';
-						$url_public_ticket = ($conf->global->TICKET_URL_PUBLIC_INTERFACE ? $conf->global->TICKET_URL_PUBLIC_INTERFACE.'/' : dol_buildpath('/public/ticket/view.php', 2)).'?track_id='.$object->track_id;
-						$message_customer .= '<p>'.$langs->trans('TicketNewEmailBodyInfosTrackUrlCustomer').' : <a href="'.$url_public_ticket.'">'.$url_public_ticket.'</a></p>';
-						$message_customer .= '<p>'.$langs->trans('TicketEmailPleaseDoNotReplyToThisEmail').'</p>';
-
-						$from = (empty($conf->global->MAIN_INFO_SOCIETE_NOM) ? '' : $conf->global->MAIN_INFO_SOCIETE_NOM.' ').'<'.$conf->global->TICKET_NOTIFICATION_EMAIL_FROM.'>';
-						$replyto = $from;
-
-						$trackid = 'tic'.$object->id;
-
-						if (!empty($conf->global->TICKET_DISABLE_MAIL_AUTOCOPY_TO)) {
-							$old_MAIN_MAIL_AUTOCOPY_TO = $conf->global->MAIN_MAIL_AUTOCOPY_TO;
-							$conf->global->MAIN_MAIL_AUTOCOPY_TO = '';
-						}
-						include_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
-						$mailfile = new CMailFile($subject, $sendto, $from, $message_customer, $filepath, $mimetype, $filename, '', '', 0, -1, '', '', $trackid, '', 'ticket');
-						if ($mailfile->error) {
-							dol_syslog($mailfile->error, LOG_DEBUG);
-						} else {
-								  $result = $mailfile->sendfile();
-						}
-						if (!empty($conf->global->TICKET_DISABLE_MAIL_AUTOCOPY_TO)) {
-							$conf->global->MAIN_MAIL_AUTOCOPY_TO = $old_MAIN_MAIL_AUTOCOPY_TO;
-						}
+						$this->ComposeAndSendCustomerMessage($sendto, $subject_customer, $body_customer, $see_ticket_customer, $object, $langs, $conf);
 					}
 				}
 
@@ -306,4 +191,137 @@ class InterfaceTicketEmail extends DolibarrTriggers
 
 		return $ok;
 	}
+
+	private function ComposeAndSendAdminMessage($sendto, $base_subject, $body, Ticket $object, Translate $langs, $conf)
+	{
+		// Init to avoid errors
+		$filepath = array();
+		$filename = array();
+		$mimetype = array();
+
+		/* Send email to admin */
+		$subject = '['.$conf->global->MAIN_INFO_SOCIETE_NOM.'] '.$langs->transnoentities($base_subject);
+		$message_admin = $langs->transnoentities($body, $object->track_id).'<br><br>';
+		$message_admin .= '<ul><li>'.$langs->trans('Title').' : '.$object->subject.'</li>';
+		$message_admin .= '<li>'.$langs->trans('Type').' : '.$langs->getLabelFromKey($this->db, 'TicketTypeShort'.$object->type_code, 'c_ticket_type', 'code', 'label', $object->type_code).'</li>';
+		$message_admin .= '<li>'.$langs->trans('Category').' : '.$langs->getLabelFromKey($this->db, 'TicketCategoryShort'.$object->category_code, 'c_ticket_category', 'code', 'label', $object->category_code).'</li>';
+		$message_admin .= '<li>'.$langs->trans('Severity').' : '.$langs->getLabelFromKey($this->db, 'TicketSeverityShort'.$object->severity_code, 'c_ticket_severity', 'code', 'label', $object->severity_code).'</li>';
+		$message_admin .= '<li>'.$langs->trans('From').' : '.($object->email_from ? $object->email_from : ($object->fk_user_create > 0 ? $langs->trans('Internal') : '')).'</li>';
+		// Extrafields
+		$extraFields = new ExtraFields($this->db);
+		$extraFields->fetch_name_optionals_label($object->table_element);
+		if (is_array($object->array_options) && count($object->array_options) > 0) {
+			foreach ($object->array_options as $key => $value) {
+				$key = substr($key, 8); // remove "options_"
+				$message_admin .= '<li>'.$langs->trans($extraFields->attributes[$object->element]['label'][$key]).' : '.$extraFields->showOutputField($key, $value, '', $object->table_element).'</li>';
+			}
+		}
+		$message_admin .= '</ul>';
+
+		if ($object->fk_soc > 0) {
+					$object->fetch_thirdparty();
+					$message_admin .= '<p>'.$langs->trans('Company').' : '.$object->thirdparty->name.'</p>';
+		}
+
+		$message = $object->message;
+		if (!dol_textishtml($message)) {
+			$message = dol_nl2br($message);
+		}
+		$message_admin .= '<p>'.$langs->trans('Message').' : <br>'.$message.'</p>';
+		$message_admin .= '<p><a href="'.dol_buildpath('/ticket/card.php', 2).'?track_id='.$object->track_id.'">'.$langs->trans('SeeThisTicketIntomanagementInterface').'</a></p>';
+
+		$from = $conf->global->MAIN_INFO_SOCIETE_NOM.'<'.$conf->global->TICKET_NOTIFICATION_EMAIL_FROM.'>';
+
+		$trackid = 'tic'.$object->id;
+
+		if (!empty($conf->global->TICKET_DISABLE_MAIL_AUTOCOPY_TO)) {
+			$old_MAIN_MAIL_AUTOCOPY_TO = $conf->global->MAIN_MAIL_AUTOCOPY_TO;
+			$conf->global->MAIN_MAIL_AUTOCOPY_TO = '';
+		}
+		include_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
+		$mailfile = new CMailFile($subject, $sendto, $from, $message_admin, $filepath, $mimetype, $filename, '', '', 0, -1, '', '', $trackid, '', 'ticket');
+		if ($mailfile->error) {
+			dol_syslog($mailfile->error, LOG_DEBUG);
+		} else {
+					$result = $mailfile->sendfile();
+		}
+		if (!empty($conf->global->TICKET_DISABLE_MAIL_AUTOCOPY_TO)) {
+			$conf->global->MAIN_MAIL_AUTOCOPY_TO = $old_MAIN_MAIL_AUTOCOPY_TO;
+		}
+	}
+
+	private function ComposeAndSendCustomerMessage ($sendto, $base_subject, $body, $see_ticket, Ticket $object, Translate $langs,  $conf)
+	{
+		// Init to avoid errors
+		$filepath = array();
+		$filename = array();
+		$mimetype = array();
+
+		$subject = '['.$conf->global->MAIN_INFO_SOCIETE_NOM.'] '.$langs->transnoentities($base_subject);
+		$message_customer = $langs->transnoentities($body, $object->track_id).'<br><br>';
+		$message_customer .= '<ul><li>'.$langs->trans('Title').' : '.$object->subject.'</li>';
+		$message_customer .= '<li>'.$langs->trans('Type').' : '.$langs->getLabelFromKey($this->db, 'TicketTypeShort'.$object->type_code, 'c_ticket_type', 'code', 'label', $object->type_code).'</li>';
+		$message_customer .= '<li>'.$langs->trans('Category').' : '.$langs->getLabelFromKey($this->db, 'TicketCategoryShort'.$object->category_code, 'c_ticket_category', 'code', 'label', $object->category_code).'</li>';
+		$message_customer .= '<li>'.$langs->trans('Severity').' : '.$langs->getLabelFromKey($this->db, 'TicketSeverityShort'.$object->severity_code, 'c_ticket_severity', 'code', 'label', $object->severity_code).'</li>';
+
+		// Extrafields
+		foreach ($this->attributes[$object->table_element]['label'] as $key => $value) {
+			$enabled = 1;
+			if ($enabled && isset($this->attributes[$object->table_element]['list'][$key])) {
+				$enabled = dol_eval($this->attributes[$object->table_element]['list'][$key], 1);
+			}
+			$perms = 1;
+			if ($perms && isset($this->attributes[$object->table_element]['perms'][$key])) {
+				$perms = dol_eval($this->attributes[$object->table_element]['perms'][$key], 1);
+			}
+
+			$qualified = true;
+			if (empty($enabled)) {
+				$qualified = false;
+			}
+			if (empty($perms)) {
+				$qualified = false;
+			}
+
+			if ($qualified) {
+				$message_customer .= '<li>'.$langs->trans($key).' : '.$value.'</li>';
+			}
+		}
+
+		$message_customer .= '</ul>';
+
+		$message = $object->message;
+		if (!dol_textishtml($message)) {
+			$message = dol_nl2br($message);
+		}
+		$message_customer .= '<p>'.$langs->trans('Message').' : <br>'.$message.'</p>';
+		$url_public_ticket = ($conf->global->TICKET_URL_PUBLIC_INTERFACE ? $conf->global->TICKET_URL_PUBLIC_INTERFACE.'/' : dol_buildpath('/public/ticket/view.php', 2)).'?track_id='.$object->track_id;
+		$message_customer .= '<p>'.$langs->trans($see_ticket).' : <a href="'.$url_public_ticket.'">'.$url_public_ticket.'</a></p>';
+		$message_customer .= '<p>'.$langs->trans('TicketEmailPleaseDoNotReplyToThisEmail').'</p>';
+
+		$from = (empty($conf->global->MAIN_INFO_SOCIETE_NOM) ? '' : $conf->global->MAIN_INFO_SOCIETE_NOM.' ').'<'.$conf->global->TICKET_NOTIFICATION_EMAIL_FROM.'>';
+
+		$trackid = 'tic'.$object->id;
+
+		if (!empty($conf->global->TICKET_DISABLE_MAIL_AUTOCOPY_TO)) {
+			$old_MAIN_MAIL_AUTOCOPY_TO = $conf->global->MAIN_MAIL_AUTOCOPY_TO;
+			$conf->global->MAIN_MAIL_AUTOCOPY_TO = '';
+		}
+		include_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
+		$mailfile = new CMailFile($subject, $sendto, $from, $message_customer, $filepath, $mimetype, $filename, '', '', 0, -1, '', '', $trackid, '', 'ticket');
+		if ($mailfile->error) {
+			dol_syslog($mailfile->error, LOG_DEBUG);
+		} else {
+			$result = $mailfile->sendfile();
+			if ($result) {
+				// update last_msg_sent date
+				$object->date_last_msg_sent = dol_now();
+				$object->update($user);
+			}
+		}
+		if (!empty($conf->global->TICKET_DISABLE_MAIL_AUTOCOPY_TO)) {
+			$conf->global->MAIN_MAIL_AUTOCOPY_TO = $old_MAIN_MAIL_AUTOCOPY_TO;
+		}
+	}
+
 }

--- a/htdocs/langs/en_US/ticket.lang
+++ b/htdocs/langs/en_US/ticket.lang
@@ -134,6 +134,10 @@ TicketsPublicNotificationNewMessage=Send email(s) when a new message/comment is 
 TicketsPublicNotificationNewMessageHelp=Send email(s) when a new message is added from public interface (to assigned user or the notifications email to (update) and/or the notifications email to)
 TicketPublicNotificationNewMessageDefaultEmail=Notifications email to (update)
 TicketPublicNotificationNewMessageDefaultEmailHelp=Send an email to this address for each new message notifications if the ticket doesn't have a user assigned to it or if the user doesn't have any known email.
+TicketsAutoNotifyClose=Automatically notify thirdparty when closing a ticket
+TicketsAutoNotifyCloseHelp=When closing a ticket, you will be proposed to send a message to one of thirdparty's contacts. On mass closing, a message will be sent to one contact of the thirdparty linked to the ticket.
+TicketWrongContact=Provided contact is not part of current ticket contacts. Email not sent.
+
 #
 # Index & list page
 #
@@ -149,6 +153,8 @@ OrderByDateAsc=Sort by ascending date
 OrderByDateDesc=Sort by descending date
 ShowAsConversation=Show as conversation list
 MessageListViewType=Show as table list
+ConfirmMassTicketClosingSendEmail=Automatically send emails when closing tickets
+ConfirmMassTicketClosingSendEmailQuestion=Do you want to notify thirdparties when closing these tickets ?
 
 #
 # Ticket card
@@ -236,6 +242,9 @@ TicketChangeStatus=Change status
 TicketConfirmChangeStatus=Confirm the status change: %s ?
 TicketLogStatusChanged=Status changed: %s to %s
 TicketNotNotifyTiersAtCreate=Not notify company at create
+NotifyThirdpartyOnTicketClosing=Contacts to notify while closing the ticket
+TicketNotifyAllTiersAtClose=All related contacts
+TicketNotNotifyTiersAtClose=No related contact
 Unread=Unread
 TicketNotCreatedFromPublicInterface=Not available. Ticket was not created from public interface.
 ErrorTicketRefRequired=Ticket reference name is required
@@ -268,6 +277,7 @@ TicketNewEmailBodyInfosTicket=Information for monitoring the ticket
 TicketNewEmailBodyInfosTrackId=Ticket tracking number: %s
 TicketNewEmailBodyInfosTrackUrl=You can view the progress of the ticket by clicking the link above.
 TicketNewEmailBodyInfosTrackUrlCustomer=You can view the progress of the ticket in the specific interface by clicking the following link
+TicketCloseEmailBodyInfosTrackUrlCustomer=You can consult the history of this ticket by clicking the following link
 TicketEmailPleaseDoNotReplyToThisEmail=Please do not reply directly to this email! Use the link to reply into the interface.
 TicketPublicInfoCreateTicket=This form allows you to record a support ticket in our management system.
 TicketPublicPleaseBeAccuratelyDescribe=Please accurately describe the problem. Provide the most information possible to allow us to correctly identify your request.
@@ -289,6 +299,10 @@ NewUser=New user
 NumberOfTicketsByMonth=Number of tickets per month
 NbOfTickets=Number of tickets
 # notifications
+TicketCloseEmailSubjectCustomer=Ticket closed
+TicketCloseEmailBodyCustomer=This is an automatic message to notify you that ticket %s has just been closed.
+TicketCloseEmailSubjectAdmin=Ticket closed - Réf %s (public ticket ID %s)
+TicketCloseEmailBodyAdmin=A ticket with ID #%s has just been closed, see information:
 TicketNotificationEmailSubject=Ticket %s updated
 TicketNotificationEmailBody=This is an automatic message to notify you that ticket %s has just been updated
 TicketNotificationRecipient=Notification recipient

--- a/htdocs/langs/fr_FR/ticket.lang
+++ b/htdocs/langs/fr_FR/ticket.lang
@@ -136,6 +136,10 @@ TicketsPublicNotificationNewMessage=Envoyer un ou des emails lorsqu’un nouveau
 TicketsPublicNotificationNewMessageHelp=Envoyer un (des) courriel(s) lorsqu’un nouveau message est ajouté à partir de l’interface publique (à l’utilisateur désigné ou au courriel de notification  (mise à jour) et/ou au courriel de notification)
 TicketPublicNotificationNewMessageDefaultEmail=Emails de notifications à (mise à jour)
 TicketPublicNotificationNewMessageDefaultEmailHelp=Envoyez un email à cette adresse email pour chaque nouveau message de notifications si le ticket n'a pas d'utilisateur assigné ou si l'utilisateur n'a pas d'email connu.
+TicketsAutoNotifyClose=Envoyer un courriel de notification aux contacts à la cloture du ticket.
+TicketsAutoNotifyCloseHelp=A la cloture de tickets, vous pouvez envoyer des emails de notification aux contacts du ticket. Cette option sélectionne par défaut "tous les contacts".
+TicketWrongContact=Le contact n'est pas lié au ticket. L'email n'a pas été envoyé.
+
 #
 # Index & list page
 #
@@ -151,6 +155,8 @@ OrderByDateAsc=Trier par date croissante
 OrderByDateDesc=Trier par date décroissante
 ShowAsConversation=Afficher comme liste de conversation
 MessageListViewType=Afficher la liste sous forme de tableau
+ConfirmMassTicketClosingSendEmail=Envoyer des emails à tous les contacts à la cloture des tickets
+ConfirmMassTicketClosingSendEmailQuestion=Voulez-vous notifier tous les contacts liés lors de la clôture de ces tickets ?
 
 #
 # Ticket card
@@ -238,6 +244,9 @@ TicketChangeStatus=Changer l'état
 TicketConfirmChangeStatus=Confirmez le changement d'état: %s?
 TicketLogStatusChanged=Statut modifié: %s à %s
 TicketNotNotifyTiersAtCreate=Ne pas notifier l'entreprise à la création
+NotifyThirdpartyOnTicketClosing=Envoyer un email de notification à :
+TicketNotifyAllTiersAtClose=Tous les contacts liés
+TicketNotNotifyTiersAtClose=Aucun contact lié
 Unread=Non lu
 TicketNotCreatedFromPublicInterface=Non disponible. Le ticket n’a pas été créé à partir de l'interface publique.
 ErrorTicketRefRequired=La référence du ticket est requise
@@ -270,6 +279,7 @@ TicketNewEmailBodyInfosTicket=Informations pour la surveillance du ticket
 TicketNewEmailBodyInfosTrackId=Numéro de suivi du ticket : %s
 TicketNewEmailBodyInfosTrackUrl=Vous pouvez voir la progression du ticket en cliquant sur le lien ci-dessus.
 TicketNewEmailBodyInfosTrackUrlCustomer=Vous pouvez voir la progression du ticket en cliquant sur le lien ci-dessus.
+TicketCloseEmailBodyInfosTrackUrlCustomer=Vous pouvez consulter l'historique du ticket en cliquant sur le lien ci-dessus.
 TicketEmailPleaseDoNotReplyToThisEmail=Merci de ne pas répondre directement à ce courriel ! Utilisez le lien pour répondre via l'interface.
 TicketPublicInfoCreateTicket=Ce formulaire vous permet d'enregistrer un ticket dans notre système de gestion.
 TicketPublicPleaseBeAccuratelyDescribe=Veuillez décrire avec précision le problème. Fournissez le plus d'informations possibles pour nous permettre d'identifier correctement votre demande.
@@ -291,6 +301,10 @@ NewUser=Nouvel utilisateur
 NumberOfTicketsByMonth=Nombre de tickets par mois
 NbOfTickets=Nombre de tickets
 # notifications
+TicketCloseEmailSubjectCustomer=Ticket clôturé
+TicketCloseEmailBodyCustomer=Ceci est un email automatique pour vous informer que le ticket %s a été clôturé.
+TicketCloseEmailSubjectAdmin=Ticket clôturé - Réf %s (ID public %s)
+TicketCloseEmailBodyAdmin=Le ticket #%s vient d'être clôturé. Voir les informations :
 TicketNotificationEmailSubject=Ticket %s mis à jour
 TicketNotificationEmailBody=Ceci est un message automatique pour vous informer que le ticket %s vient d'être mis à jour
 TicketNotificationRecipient=Destinataire de la notification

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -772,10 +772,28 @@ if ($action == 'create' || $action == 'presend') {
 
 		// Confirmation close
 		if ($action == 'close') {
-			print $form->formconfirm($url_page_current."?track_id=".$object->track_id, $langs->trans("CloseATicket"), $langs->trans("ConfirmCloseAticket"), "confirm_close", '', '', 1);
-			if ($ret == 'html') {
-				print '<br>';
+			$thirdparty_contacts = $object->getInfosTicketExternalContact();
+			$contacts_select = array(
+				'-2' => $langs->trans('TicketNotifyAllTiersAtClose'),
+				'-3' => $langs->trans('TicketNotNotifyTiersAtClose')
+			);
+			foreach ($thirdparty_contacts as $thirdparty_contact) {
+			    $contacts_select[$thirdparty_contact['id']] = $thirdparty_contact['civility'] . ' ' . $thirdparty_contact['lastname'] . ' ' . $thirdparty_contact['firstname'];
 			}
+
+			// Default select all or no contact
+			$default = (!empty($conf->global->TICKET_NOTIFY_AT_CLOSING)) ? -2 : -3;
+			$formquestion = array(
+				array(
+					'name' => 'contactid',
+					'type' => 'select',
+					'label' => $langs->trans('NotifyThirdpartyOnTicketClosing'),
+					'values' => $contacts_select,
+					'default' => $default
+				),
+			);
+
+			print $form->formconfirm($url_page_current."?track_id=".$object->track_id, $langs->trans("CloseATicket"), $langs->trans("ConfirmCloseAticket"), "confirm_close", $formquestion, '', 1 );
 		}
 		// Confirmation abandon
 		if ($action == 'abandon') {

--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -184,7 +184,7 @@ $error = 0;
 if (GETPOST('cancel', 'alpha')) {
 	$action = 'list'; $massaction = '';
 }
-if (!GETPOST('confirmmassaction', 'alpha') && $massaction != 'presend' && $massaction != 'confirm_presend') {
+if (!GETPOST('confirmmassaction', 'alpha') && $massaction != 'presend' && $massaction != 'confirm_presend' && $massaction != 'presendonclose' && $massaction != 'close') {
 	$massaction = '';
 }
 
@@ -676,7 +676,7 @@ $arrayofmassactions = array(
 	//'builddoc'=>img_picto('', 'pdf', 'class="pictofixedwidth"').$langs->trans("PDFMerge"),
 );
 if ($user->rights->ticket->write) {
-	$arrayofmassactions['close'] = img_picto('', 'close_title', 'class="pictofixedwidth"').$langs->trans("Close");
+	$arrayofmassactions['presendonclose'] = img_picto('', 'close_title', 'class="pictofixedwidth"').$langs->trans("Close");
 }
 if ($user->rights->ticket->write) {
 	$arrayofmassactions['reopen'] = img_picto('', 'folder-open', 'class="pictofixedwidth"').$langs->trans("ReOpen");
@@ -730,6 +730,17 @@ $modelmail = "ticket";
 $objecttmp = new Ticket($db);
 $trackid = 'tic'.$object->id;
 include DOL_DOCUMENT_ROOT.'/core/tpl/massactions_pre.tpl.php';
+
+// confirm auto send on close
+if ($massaction == 'presendonclose') {
+	$hidden_form = array([
+		"type" => "hidden",
+		"name" => "massaction",
+		"value" => "close"
+	]);
+	$selectedchoice = (!empty($conf->global->TICKET_NOTIFY_AT_CLOSING)) ? "yes" : "no";
+	print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans("ConfirmMassTicketClosingSendEmail"), $langs->trans("ConfirmMassTicketClosingSendEmailQuestion"), 'confirm_send_close', $hidden_form, $selectedchoice, 0, 200, 500, 1);
+}
 
 if ($search_all) {
 	foreach ($fieldstosearchall as $key => $val) {


### PR DESCRIPTION
New Ticket: notification email on closing

This PR allows to notify all contacts of the ticket:
- on single ticket closing (from ticket/card/php)
- on mass ticket closing (from ticket/list.php)



It adds a modification to ticket card closing modal to allow chosing the mail receiver between:
- all contacts
- no contact
- contact 1, contact 2, etc.

![modale_confirmation](https://user-images.githubusercontent.com/89838020/156015644-9f7c6058-5524-461e-bf0e-50efa19a33a8.png)

It adds a confirmation before mass ticket closing to chose to send (or not) the emails to all contacts.

![cloture_mass_confirm](https://user-images.githubusercontent.com/89838020/156015615-dff7118c-123f-4529-81ab-fbfae7f58d84.png)

It introduces option TICKET_NOTIFY_AT_CLOSING and adds a line in ticket config panel.