### PR TITLE
2022.5 new: check invoice date (#20247)

### DIFF
--- a/htdocs/admin/facture.php
+++ b/htdocs/admin/facture.php
@@ -223,6 +223,12 @@ if ($action == 'updateMask') {
 			setEventMessages($langs->trans("Error"), null, 'errors');
 		}
 	}
+} elseif ($action == 'set_INVOICE_CHECK_POSTERIOR_DATE') {
+	$check_posterior_date = GETPOST('INVOICE_CHECK_POSTERIOR_DATE', 'int');
+	$res = dolibarr_set_const($db, 'INVOICE_CHECK_POSTERIOR_DATE', $check_posterior_date, 'chaine', 0, '', $conf->entity);
+	if (!($res > 0)) {
+		$error++;
+	}
 }
 
 
@@ -758,6 +764,25 @@ print '</td><td class="right">';
 print '<input type="submit" class="button" value="'.$langs->trans("Modify").'" />';
 print "</td></tr>\n";
 print '</form>';
+
+
+print '<tr class="oddeven"><td>'.$langs->trans("InvoiceCheckPosteriorDate"). '&nbsp;' ;
+print $form->textwithpicto('', $langs->trans("InvoiceCheckPosteriorDateHelp"), 1, 'help') . '</td>';
+print '<td class="left">';
+if ($conf->use_javascript_ajax) {
+	print ajax_constantonoff('INVOICE_CHECK_POSTERIOR_DATE');
+} else {
+	print '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';
+	print '<input type="hidden" name="token" value="'.newToken().'" />';
+	print '<input type="hidden" name="action" value="set_INVOICE_CHECK_POSTERIOR_DATE" />';
+	$arrval = array('0' => $langs->trans("No"), '1' => $langs->trans("Yes"));
+	print $form->selectarray("INVOICE_CHECK_POSTERIOR_DATE", $arrval, $conf->global->INVOICE_CHECK_POSTERIOR_DATE);
+	print '</td>';
+	print '<td class="center">';
+	print '<input type="submit" class="button" value="'.$langs->trans("Modify").'" />';
+	print '</form>';
+}
+print '</td></tr>';
 
 print '</table>';
 print '</div>';

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -283,6 +283,15 @@ if (empty($reshook)) {
 		// Validation
 		$object->fetch($id);
 
+		if (!empty($conf->global-> INVOICE_CHECK_POSTERIOR_DATE)) {
+			$last_of_type = $object->willBeLastOfSameType();
+			if (empty($object->date_validation) && !$last_of_type[0]) {
+				setEventMessages($langs->transnoentities("ErrorInvoiceIsNotLastOfSameType", $object->ref , dol_print_date($object->date, 'day'), dol_print_date($last_of_type[1], 'day')), null, 'errors');
+				header('Location: '.$_SERVER["PHP_SELF"].'?facid='.$id);
+				exit;
+			}
+		}
+
 		// On verifie signe facture
 		if ($object->type == Facture::TYPE_CREDIT_NOTE) {
 			// Si avoir, le signe doit etre negatif

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2656,6 +2656,13 @@ class Facture extends CommonInvoice
 			dol_syslog(get_class($this)."::validate ".$this->error.' MAIN_USE_ADVANCED_PERMS='.$conf->global->MAIN_USE_ADVANCED_PERMS, LOG_ERR);
 			return -1;
 		}
+		if (!empty($conf->global-> INVOICE_CHECK_POSTERIOR_DATE)) {
+			$last_of_type = $this->willBeLastOfSameType();
+			if (!$last_of_type[0]) {
+				$this->error = $langs->transnoentities("ErrorInvoiceIsNotLastOfSameType", $this->ref , dol_print_date($this->date, 'day'), dol_print_date($last_of_type[1], 'day'));
+				return -1;
+			}
+		}
 
 		$this->db->begin();
 

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -5106,6 +5106,38 @@ class Facture extends CommonInvoice
 			return $error;
 		}
 	}
+
+	/**
+	 * See if current invoice date is posterior to the last invoice date among validated invoices of same type.
+	 * @param bool 	$strict		compare precise time or only days.
+	 * @return boolean
+	 */
+	public function willBeLastOfSameType()
+	{
+		// get date of last validated invoices of same type
+		$sql  = 'SELECT datef';
+		$sql .= ' FROM '.MAIN_DB_PREFIX.'facture';
+		$sql .= ' WHERE type = ' . (int) $this->type ;
+		$sql .= ' AND date_valid IS NOT NULL';
+		$sql .= ' ORDER BY datef DESC LIMIT 1';
+
+		$result = $this->db->query($sql);
+		if ($result) {
+			// compare with current validation date
+			if ($this->db->num_rows($result)) {
+				$obj = $this->db->fetch_object($result);
+				$last_date = $this->db->jdate($obj->datef);
+				$invoice_date = $this->date;
+
+				return [$invoice_date >= $last_date, $last_date];
+			} else {
+				// element is first of type to be validated
+				return [true];
+			}
+		} else {
+			dol_print_error($this->db);
+		}
+	}
 }
 
 /**

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1213,7 +1213,7 @@ if (!$error && $massaction == 'validate' && $permissiontoadd) {
 		if (!empty($toselect) && !empty($conf->global->INVOICE_CHECK_POSTERIOR_DATE)) {
 			// order $toselect by date
 			$sql  = 'SELECT rowid FROM '.MAIN_DB_PREFIX.'facture';
-			$sql .= ' WHERE rowid IN ('.$db->escape(implode(', ', $toselect)).')';
+			$sql .= ' WHERE rowid IN ('.$db->sanitize(implode(',', $toselect)).')';
 			$sql .= ' ORDER BY datef';
 
 			$resql = $db->query($sql);

--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1209,6 +1209,26 @@ if (!$error && $massaction == 'validate' && $permissiontoadd) {
 		setEventMessages($langs->trans('ErrorMassValidationNotAllowedWhenStockIncreaseOnAction'), null, 'errors');
 		$error++;
 	}
+	if ($objecttmp->element == 'facture') {
+		if (!empty($toselect) && !empty($conf->global->INVOICE_CHECK_POSTERIOR_DATE)) {
+			// order $toselect by date
+			$sql  = 'SELECT rowid FROM '.MAIN_DB_PREFIX.'facture';
+			$sql .= ' WHERE rowid IN ('.$db->escape(implode(', ', $toselect)).')';
+			$sql .= ' ORDER BY datef';
+
+			$resql = $db->query($sql);
+			if ($resql) {
+				$toselectnew = [];
+				while ( !empty($arr = $db->fetch_row($resql))) {
+					$toselectnew[] = $arr[0];
+				}
+				$toselect = (empty($toselectnew)) ? $toselect : $toselectnew;
+			} else {
+				dol_print_error($db);
+				$error++;
+			}
+		}
+	}
 	if (!$error) {
 		$db->begin();
 

--- a/htdocs/core/modules/modFacture.class.php
+++ b/htdocs/core/modules/modFacture.class.php
@@ -106,6 +106,13 @@ class modFacture extends DolibarrModules
 		$this->const[$r][4] = 0;
 		$r++;*/
 
+		$this->const[$r][0] = "INVOICE_CHECK_POSTERIOR_DATE";
+		$this->const[$r][1] = "chaine";
+		$this->const[$r][2] = 0;
+		$this->const[$r][3] = "When validating an invoice, check that its date is posterior to last invoice date for invoices of same type.";
+		$this->const[$r][4] = 0;
+		$r++;
+
 
 		// Boxes
 		//$this->boxes = array(0=>array(1=>'box_factures_imp.php'),1=>array(1=>'box_factures.php'));

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -1401,6 +1401,8 @@ WatermarkOnDraftInvoices=Watermark on draft invoices (none if empty)
 PaymentsNumberingModule=Payments numbering model
 SuppliersPayment=Vendor payments
 SupplierPaymentSetup=Vendor payments setup
+InvoiceCheckPosteriorDate=Check facture date before validation
+InvoiceCheckPosteriorDateHelp=Validating an invoice will be forbidden if its date is anterior to the date of last invoice of same type.
 ##### Proposals #####
 PropalSetup=Commercial proposals module setup
 ProposalsNumberingModules=Commercial proposal numbering models

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -157,6 +157,7 @@ ErrorInvoiceAvoirMustBeNegative=Error, correct invoice must have a negative amou
 ErrorInvoiceOfThisTypeMustBePositive=Error, this type of invoice must have an amount excluding tax positive (or null)
 ErrorCantCancelIfReplacementInvoiceNotValidated=Error, can't cancel an invoice that has been replaced by another invoice that is still in draft status
 ErrorThisPartOrAnotherIsAlreadyUsedSoDiscountSerieCantBeRemoved=This part or another is already used so discount series cannot be removed.
+ErrorInvoiceIsNotLastOfSameType=Error: The date of invoice %s  is %s. It must be posterior or equal to last date for same type invoices (%s). Please change the invoice date.
 BillFrom=From
 BillTo=To
 ActionsOnBill=Actions on invoice

--- a/htdocs/langs/fr_FR/admin.lang
+++ b/htdocs/langs/fr_FR/admin.lang
@@ -1421,6 +1421,8 @@ WatermarkOnDraftInvoices=Filigrane sur les brouillons de factures (aucun si vide
 PaymentsNumberingModule=Modèle de numérotation des paiements
 SuppliersPayment=Règlements fournisseurs
 SupplierPaymentSetup=Configuration des règlements fournisseurs
+InvoiceCheckPosteriorDate=Vérifier les dates de facturation à la validation
+InvoiceCheckPosteriorDateHelp=La validation des factures sera refusée si la date de facturation est antérieure à la date de la dernière facture du même type.
 ##### Proposals #####
 PropalSetup=Configuration du module Propositions Commerciales
 ProposalsNumberingModules=Modèles de numérotation des propositions commerciales

--- a/htdocs/langs/fr_FR/bills.lang
+++ b/htdocs/langs/fr_FR/bills.lang
@@ -157,6 +157,7 @@ ErrorInvoiceAvoirMustBeNegative=Erreur, une facture de type Avoir doit avoir un 
 ErrorInvoiceOfThisTypeMustBePositive=Erreur, une facture de ce type doit avoir un montant hors taxe positif (ou nul)
 ErrorCantCancelIfReplacementInvoiceNotValidated=Erreur, il n'est pas possible d'annuler une facture qui a été remplacée par une autre qui se trouve toujours à l'état 'brouillon'.
 ErrorThisPartOrAnotherIsAlreadyUsedSoDiscountSerieCantBeRemoved=Cette partie ou une autre est déjà utilisé, aussi la remise ne peut être supprimée.
+ErrorInvoiceIsNotLastOfSameType=Erreur : La facture %s est datée du %s. Elle doit être postérieure ou égale à la date de la dernière facture de même type (%s). Veuillez modifier la date de la facture.
 BillFrom=Émetteur
 BillTo=Adressé à
 ActionsOnBill=Événements sur la facture


### PR DESCRIPTION
NEW check invoice date

Introduces an option to check invoices dates on validation.
When activated, validating an invoice will be forbidden if its date is anterior to the date of last invoice of same type.

This introduces INVOICE_CHECK_POSTERIOR_DATE constant.

Dolibarr Issue https://github.com/Dolibarr/dolibarr/issues/20234