### PR TITLE
fix ticket extrafields not being displayed in public list

### DIFF
--- a/htdocs/public/ticket/list.php
+++ b/htdocs/public/ticket/list.php
@@ -653,7 +653,7 @@ if ($action == "view_ticketlist") {
 								}
 								print '>';
 								$tmpkey = 'options_'.$key;
-								print $extrafields->showOutputField($key, $obj->$tmpkey, '', 1);
+								print $extrafields->showOutputField($key, $obj->$tmpkey, '', $object->table_element);
 								print '</td>';
 							}
 						}


### PR DESCRIPTION
Ticket extrafields were not correctly displayed in ticket public view.
This is a backport of a fix in develop. (commit 186185267e7a0ee4c4f2dae7446a1606892bd26e)