### PR TITLE
NEW option update prices on proposal cloning (PR #20255)

### DIFF
--- a/htdocs/admin/propal.php
+++ b/htdocs/admin/propal.php
@@ -196,6 +196,37 @@ if ($action == 'updateMask') {
 	// par appel methode canBeActivated
 
 	dolibarr_set_const($db, "PROPALE_ADDON", $value, 'chaine', 0, '', $conf->entity);
+} elseif (preg_match('/set_(.*)/',$action,$reg)) {
+	$code = $reg[1];
+	$value=(GETPOST($code) ? GETPOST($code) : 1);
+
+	$res = dolibarr_set_const($db, $code, $value, 'chaine', 0, '', $conf->entity);
+	if (!($res > 0)) {
+		$error++;
+	}
+
+	if ($error) {
+		setEventMessages($langs->trans('Error'), null, 'errors');
+	} else {
+		setEventMessages($langs->trans('SetupSaved'), null, 'mesgs');
+		header("Location: " . $_SERVER["PHP_SELF"]);
+		exit();
+	}
+} elseif (preg_match('/del_(.*)/',$action,$reg)) {
+	$code = $reg[1];
+	$res = dolibarr_del_const($db, $code, $conf->entity);
+
+	if (!($res > 0)) {
+		$error++;
+	}
+
+	if ($error) {
+		setEventMessages($langs->trans('Error'), null, 'errors');
+	} else {
+		setEventMessages($langs->trans('SetupSaved'), null, 'mesgs');
+		header("Location: " . $_SERVER["PHP_SELF"]);
+		exit();
+	}
 }
 
 
@@ -588,6 +619,26 @@ print '<tr class="oddeven">';
 print '<td>'.$langs->trans("DefaultProposalDurationValidity").'</td>';
 print '<td width="60" align="center">'."<input size=\"3\" class=\"flat\" type=\"text\" name=\"value\" value=\"".$conf->global->PROPALE_VALIDITY_DURATION."\"></td>";
 print '<td class="right"><input type="submit" class="button" value="'.$langs->trans("Modify").'"></td>';
+print '</tr>';
+print '</form>';
+
+// default update prices on cloning a proposal
+print '<form method="post" action="' . $_SERVER["PHP_SELF"] . '">';
+print '<input type="hidden" name="token" value="' . newToken() .'">';
+print '<tr class="oddeven">';
+print '<td>' . $langs->trans('DefaultPuttingPricesUpToDate').'</td>';
+print '<td></td>';
+print '<td class="right">';
+if (!empty($conf->use_javascript_ajax)) {
+	print ajax_constantonoff('PROPOSAL_CLONE_UPDATE_PRICES', array(), $conf->entity, 0, 0, 1, 0);
+} else {
+	if (empty($conf->global->PROPOSAL_CLONE_UPDATE_PRICES)) {
+		print '<a href="' . $_SERVER['PHP_SELF'] . '?action=set_PROPOSAL_CLONE_UPDATE_PRICES">' . img_picto($langs->trans('Disabled'), 'switch_off') . '</a>';
+	} else {
+		print '<a href="' . $_SERVER['PHP_SELF'] . '?action=del_PROPOSAL_CLONE_UPDATE_PRICES">' . img_picto($langs->trans('Enabled'), 'switch_on') . '</a>';
+	}
+}
+print '</td>';
 print '</tr>';
 print '</form>';
 

--- a/htdocs/admin/propal.php
+++ b/htdocs/admin/propal.php
@@ -196,9 +196,9 @@ if ($action == 'updateMask') {
 	// par appel methode canBeActivated
 
 	dolibarr_set_const($db, "PROPALE_ADDON", $value, 'chaine', 0, '', $conf->entity);
-} elseif (preg_match('/set_(.*)/',$action,$reg)) {
+} elseif (preg_match('/set_(.*)/', $action, $reg)) {
 	$code = $reg[1];
-	$value=(GETPOST($code) ? GETPOST($code) : 1);
+	$value = (GETPOST($code) ? GETPOST($code) : 1);
 
 	$res = dolibarr_set_const($db, $code, $value, 'chaine', 0, '', $conf->entity);
 	if (!($res > 0)) {
@@ -212,7 +212,7 @@ if ($action == 'updateMask') {
 		header("Location: " . $_SERVER["PHP_SELF"]);
 		exit();
 	}
-} elseif (preg_match('/del_(.*)/',$action,$reg)) {
+} elseif (preg_match('/del_(.*)/', $action, $reg)) {
 	$code = $reg[1];
 	$res = dolibarr_del_const($db, $code, $conf->entity);
 

--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -205,7 +205,7 @@ if (empty($reshook)) {
 					}
 				}
 
-				$result = $object->createFromClone($user, $socid, (GETPOSTISSET('entity') ? GETPOST('entity', 'int') : null));
+				$result = $object->createFromClone($user, $socid, (GETPOSTISSET('entity') ? GETPOST('entity', 'int') : null), GETPOSTISSET('update_prices'));
 				if ($result > 0) {
 					header("Location: ".$_SERVER['PHP_SELF'].'?id='.$result);
 					exit();
@@ -1903,8 +1903,8 @@ if ($action == 'create') {
 		$formquestion = array(
 			// 'text' => $langs->trans("ConfirmClone"),
 			// array('type' => 'checkbox', 'name' => 'clone_content', 'label' => $langs->trans("CloneMainAttributes"), 'value' => 1),
-			// array('type' => 'checkbox', 'name' => 'update_prices', 'label' => $langs->trans("PuttingPricesUpToDate"), 'value' => 1),
-			array('type' => 'other', 'name' => 'socid', 'label' => $langs->trans("SelectThirdParty"), 'value' => $form->select_company(GETPOST('socid', 'int'), 'socid', '(s.client=1 OR s.client=2 OR s.client=3)'))
+			array('type' => 'other', 'name' => 'socid', 'label' => $langs->trans("SelectThirdParty"), 'value' => $form->select_company(GETPOST('socid', 'int'), 'socid', '(s.client=1 OR s.client=2 OR s.client=3)')),
+			array('type' => 'checkbox', 'name' => 'update_prices', 'label' => $langs->trans('PuttingPricesUpToDate'), 'value' => 1),
 		);
 		if (!empty($conf->global->PROPAL_CLONE_DATE_DELIVERY) && !empty($object->delivery_date)) {
 			$formquestion[] = array('type' => 'date', 'name' => 'date_delivery', 'label' => $langs->trans("DeliveryDate"), 'value' => $object->delivery_date);

--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -205,7 +205,7 @@ if (empty($reshook)) {
 					}
 				}
 
-				$result = $object->createFromClone($user, $socid, (GETPOSTISSET('entity') ? GETPOST('entity', 'int') : null), GETPOSTISSET('update_prices'));
+				$result = $object->createFromClone($user, $socid, (GETPOSTISSET('entity') ? GETPOST('entity', 'int') : null), (GETPOST('update_prices', 'aZ') ? true : false));
 				if ($result > 0) {
 					header("Location: ".$_SERVER['PHP_SELF'].'?id='.$result);
 					exit();
@@ -1904,7 +1904,7 @@ if ($action == 'create') {
 			// 'text' => $langs->trans("ConfirmClone"),
 			// array('type' => 'checkbox', 'name' => 'clone_content', 'label' => $langs->trans("CloneMainAttributes"), 'value' => 1),
 			array('type' => 'other', 'name' => 'socid', 'label' => $langs->trans("SelectThirdParty"), 'value' => $form->select_company(GETPOST('socid', 'int'), 'socid', '(s.client=1 OR s.client=2 OR s.client=3)')),
-			array('type' => 'checkbox', 'name' => 'update_prices', 'label' => $langs->trans('PuttingPricesUpToDate'), 'value' => 1),
+			array('type' => 'checkbox', 'name' => 'update_prices', 'label' => $langs->trans('PuttingPricesUpToDate'), 'value' => (!empty($conf->global->PROPOSAL_CLONE_UPDATE_PRICES) ? 1 : 0)),
 		);
 		if (!empty($conf->global->PROPAL_CLONE_DATE_DELIVERY) && !empty($object->delivery_date)) {
 			$formquestion[] = array('type' => 'date', 'name' => 'date_delivery', 'label' => $langs->trans("DeliveryDate"), 'value' => $object->delivery_date);

--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -399,4 +399,4 @@ ProductSupplierExtraFields=Additional Attributes (Supplier Prices)
 DeleteLinkedProduct=Delete the child product linked to the combination
 PMPValue=Weighted average price
 PMPValueShort=WAP
-PuttingPricesUpToDate=Update prices
+PuttingPricesUpToDate=Update prices with current known prices

--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -399,3 +399,4 @@ ProductSupplierExtraFields=Additional Attributes (Supplier Prices)
 DeleteLinkedProduct=Delete the child product linked to the combination
 PMPValue=Weighted average price
 PMPValueShort=WAP
+PuttingPricesUpToDate=Update prices

--- a/htdocs/langs/en_US/propal.lang
+++ b/htdocs/langs/en_US/propal.lang
@@ -54,6 +54,7 @@ NoDraftProposals=No draft proposals
 CopyPropalFrom=Create commercial proposal by copying existing proposal
 CreateEmptyPropal=Create empty commercial proposal or from list of products/services
 DefaultProposalDurationValidity=Default commercial proposal validity duration (in days)
+DefaultPuttingPricesUpToDate=By default update prices with current known prices on cloning a proposal
 UseCustomerContactAsPropalRecipientIfExist=Use contact/address with type 'Contact following-up proposal' if defined instead of third party address as proposal recipient address
 ConfirmClonePropal=Are you sure you want to clone the commercial proposal <b>%s</b>?
 ConfirmReOpenProp=Are you sure you want to open back the commercial proposal <b>%s</b>?

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -408,3 +408,4 @@ mandatoryHelper=Message to the user on the need to enter a start date and an end
 DefaultBOM=Nomenclature par défaut
 DefaultBOMDesc=La nomenclature par défaut qu'il est recommandé d'utiliser pour fabriquer ce produit. Ce champ ne peut être défini que si la nature du produit est '%s'.
 Rank=Classement
+PuttingPricesUpToDate=Mettre à jour les tarifs

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -408,4 +408,4 @@ mandatoryHelper=Message to the user on the need to enter a start date and an end
 DefaultBOM=Nomenclature par défaut
 DefaultBOMDesc=La nomenclature par défaut qu'il est recommandé d'utiliser pour fabriquer ce produit. Ce champ ne peut être défini que si la nature du produit est '%s'.
 Rank=Classement
-PuttingPricesUpToDate=Mettre à jour les tarifs
+PuttingPricesUpToDate=Mettre à jour les prix

--- a/htdocs/langs/fr_FR/propal.lang
+++ b/htdocs/langs/fr_FR/propal.lang
@@ -54,6 +54,7 @@ NoDraftProposals=Pas de propositions brouillons
 CopyPropalFrom=Créer proposition/devis par recopie d'un proposition existante
 CreateEmptyPropal=Créer proposition/devis vierge ou avec la liste des produits/services
 DefaultProposalDurationValidity=Délai de validité par défaut (en jours)
+DefaultPuttingPricesUpToDate=Par défaut, mettre à jour les prix lors de clonage d'une proposition commerciale
 UseCustomerContactAsPropalRecipientIfExist=Utiliser l'adresse de 'contact suivi client' si définie plutôt que l'adresse du tiers comme destinataire des propositions
 ConfirmClonePropal=Êtes-vous sûr de vouloir cloner la proposition commerciale <b>%s</b> ?
 ConfirmReOpenProp=Êtes-vous sûr de vouloir réouvrir la proposition commerciale <b>%s</b> ?


### PR DESCRIPTION
NEW option update prices on proposal cloning

Add a check box in dialog box before cloning a proposal :
![image](https://user-images.githubusercontent.com/45359511/156552356-25232572-f892-4e8e-abb9-12c1828667e9.png)

Rules on price :
- if only one price : get product price by default
- if serveral price levels : get price linked to thirdparty price level (const PRODUIT_MULTIPRICES)
- if one price for each customer : get price of selected company before cloning the prosposal (const PRODUIT_CUSTOMER_PRICES)

Rules on VAT : 
- get default VAT with the seller and the new buyer
- change it with product prices rules defined in product setup (PRODUIT_MULTIPRICES and PRODUIT_CUSTOMER_PRICES)

Rules on discount : 
- get by default the selected company discount
