### PR TITLE
2022.5 ticket workflow auto create intervention (#20392)

### DIFF
--- a/htdocs/admin/ticket.php
+++ b/htdocs/admin/ticket.php
@@ -582,7 +582,6 @@ print '</div>';
 
 print '</form>';
 
-
 // Admin var of module
 print load_fiche_titre($langs->trans("Notification"), '', '');
 

--- a/htdocs/admin/ticket.php
+++ b/htdocs/admin/ticket.php
@@ -582,6 +582,7 @@ print '</div>';
 
 print '</form>';
 
+
 // Admin var of module
 print load_fiche_titre($langs->trans("Notification"), '', '');
 

--- a/htdocs/admin/ticket.php
+++ b/htdocs/admin/ticket.php
@@ -543,10 +543,10 @@ if ($conf->use_javascript_ajax) {
 
 print '<tr class="oddeven"><td>'.$langs->trans("TicketChooseProductCategory").'</td>';
 print '<td class="left">';
-	$form->selectProductCategory($conf->global->TICKET_PRODUCT_CATEGORY, 'product_category_id');
-	if ($conf->use_javascript_ajax) {
-		print ajax_combobox('select_'.$htmlname);
-	}
+$form->selectProductCategory($conf->global->TICKET_PRODUCT_CATEGORY, 'product_category_id');
+if ($conf->use_javascript_ajax) {
+	print ajax_combobox('select_'.$htmlname);
+}
 print '</td>';
 print '<td class="center">';
 print $form->textwithpicto('', $langs->trans("TicketChooseProductCategoryHelp"), 1, 'help');

--- a/htdocs/admin/workflow.php
+++ b/htdocs/admin/workflow.php
@@ -139,7 +139,21 @@ $workflowcodes = array(
 		'position' => 66,
 		'enabled' => ! empty($conf->expedition->enabled) && ! empty($conf->facture->enabled),
 		'picto' => 'shipment'
-	)
+	),
+
+	// Automatic link ticket -> contract
+	'WORKFLOW_TICKET_LINK_CONTRACT' => array(
+		'family' => 'link_ticket',
+		'position' => 75,
+		'enabled' => ! empty($conf->ticket->enabled) && ! empty($conf->contract->enabled),
+		'picto' => 'ticket'
+	),
+	'WORKFLOW_TICKET_USE_PARENT_COMPANY_CONTRACTS' => array(
+		'family' => 'link_ticket',
+		'position' => 76,
+		'enabled' => ! empty($conf->ticket->enabled) && ! empty($conf->contract->enabled),
+		'picto' => 'ticket'
+	),
 );
 
 if (!empty($conf->modules_parts['workflow']) && is_array($conf->modules_parts['workflow'])) {
@@ -214,6 +228,11 @@ foreach ($workflowcodes as $key => $params) {
 			}
 			if ($reg[1] == 'shipping') {
 				$header .= ' - '.$langs->trans('Shipment');
+			}
+		} elseif (preg_match('/link_(.*)/', $params['family'], $reg)) {
+			$header = $langs->trans("AutomaticLinking");
+			if ($reg[1] == 'ticket') {
+				$header .= ' - '.$langs->trans('Ticket');
 			}
 		} else {
 			$header = $langs->trans("Description");

--- a/htdocs/admin/workflow.php
+++ b/htdocs/admin/workflow.php
@@ -71,6 +71,12 @@ $workflowcodes = array(
 		'enabled'=>(!empty($conf->commande->enabled) && !empty($conf->facture->enabled)),
 		'picto'=>'bill'
 	),
+	'WORKFLOW_TICKET_CREATE_INTERVENTION' => array (
+        'family'=>'create',
+        'position'=>25,
+        'enabled'=>(!empty($conf->ticket->enabled) && !empty($conf->ficheinter->enabled)),
+        'picto'=>'ticket'
+	),
 
 	'separator1'=>array('family'=>'separator', 'position'=>25, 'title'=>''),
 

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -2143,7 +2143,7 @@ class Contrat extends CommonObject
 	 *	@param	array		$line_status			sort contracts where lines have these status
 	 *  @return array|int   						Array of contracts id or <0 if error
 	 */
-	public function getListOfContracts($option = 'all', $status = [], $product_categories = [], $line_status = [] )
+	public function getListOfContracts($option = 'all', $status = [], $product_categories = [], $line_status = [])
 	{
 		$tab = array();
 

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -2151,12 +2151,12 @@ class Contrat extends CommonObject
 		$sql .= " FROM ".MAIN_DB_PREFIX."contrat as c";
 		if (!empty($product_categories)) {
 			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."contratdet as cd ON cd.fk_contrat = c.rowid";
-			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."categorie_product as cp ON cp.fk_product = cd.fk_product AND cp.fk_categorie IN (".implode(', ', $product_categories).")";
+			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."categorie_product as cp ON cp.fk_product = cd.fk_product AND cp.fk_categorie IN (".$this->db->sanitize(implode(', ', $product_categories)).")";
 		}
 		$sql .= " WHERE c.fk_soc =".((int) $this->socid);
 		$sql .= ($option == 'others') ? " AND c.rowid <> ".((int) $this->id) : "";
-		$sql .= (!empty($status)) ? " AND c.statut IN (".implode(', ', $status).")" : "";
-		$sql .= (!empty($line_status)) ? " AND cd.statut IN (".implode(', ', $line_status).")" : "";
+		$sql .= (!empty($status)) ? " AND c.statut IN (".$this->db->sanitize(implode(', ', $status)).")" : "";
+		$sql .= (!empty($line_status)) ? " AND cd.statut IN (".$this->db->sanitize(implode(', ', $line_status)).")" : "";
 		$sql .= " GROUP BY c.rowid";
 
 		dol_syslog(get_class($this)."::getOtherContracts()", LOG_DEBUG);

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -3585,7 +3585,6 @@ class Form
 		}
 	}
 
-
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
 	 *      Load into cache list of payment terms

--- a/htdocs/core/class/html.formcategory.class.php
+++ b/htdocs/core/class/html.formcategory.class.php
@@ -60,4 +60,44 @@ class FormCategory extends Form
 
 		return $filter;
 	}
+
+	/**
+	 *    Prints a select form for products categories
+	 *    @param    string	$selected          	Id category pre-selection
+	 *    @param    string	$htmlname          	Name of HTML field
+	 *    @param    int		$showempty         	Add an empty field
+	 *    @return	integer|null
+	 */
+	public function selectProductCategory($selected = 0, $htmlname = 'product_category_id', $showempty = 0)
+	{
+		global $conf;
+
+		$sql = "SELECT cp.fk_categorie as cat_index, cat.label FROM `llx_categorie_product` as cp INNER JOIN llx_categorie as cat ON cat.rowid = cp.fk_categorie GROUP BY cp.fk_categorie;";
+
+		dol_syslog(get_class($this)."::selectProductCategory", LOG_DEBUG);
+		$resql = $this->db->query($sql);
+		if ($resql) {
+			print '<select class="flat" id="select_'.$htmlname.'" name="'.$htmlname.'">';
+			if ($showempty) {
+				print '<option value="0">&nbsp;</option>';
+			}
+
+			$i = 0;
+			$num_rows = $this->db->num_rows($resql);
+			while ($i < $num_rows) {
+				$category = $this->db->fetch_object($resql);
+				if ($selected && $selected == $category->cat_index) {
+					print '<option value="'.$category->cat_index.'" selected>'.$category->label.'</option>';
+				} else {
+					print '<option value="'.$category->cat_index.'">'.$category->label.'</option>';
+				}
+				$i++;
+			}
+			print ('</select>');
+
+			return $num_rows;
+		} else {
+			dol_print_error($this->db);
+		}
+	}
 }

--- a/htdocs/core/modules/modTicket.class.php
+++ b/htdocs/core/modules/modTicket.class.php
@@ -109,7 +109,8 @@ class modTicket extends DolibarrModules
 			3 => array('TICKET_ADDON_PDF_ODT_PATH', 'chaine', 'DOL_DATA_ROOT/doctemplates/tickets', 'Ticket templates ODT/ODS directory for templates', 0),
 			4 => array('TICKET_NOTIFY_AT_CLOSING', 'chaine', '0', 'Automatically notify contacts when closing a module', 0),
 			5 => array('TICKET_DELAY_BEFORE_FIRST_RESPONSE', 'chaine', '0', 'Maximum wanted elapsed time before a first answer to a ticket (in hours). Display a warning in tickets list if not respected.', 0),
-			6 => array('TICKET_DELAY_SINCE_LAST_RESPONSE', 'chaine', '0', 'Maximum wanted elapsed time between two answers on the same ticket (in hours). Display a warning in tickets list if not respected.', 0)
+			6 => array('TICKET_DELAY_SINCE_LAST_RESPONSE', 'chaine', '0', 'Maximum wanted elapsed time between two answers on the same ticket (in hours). Display a warning in tickets list if not respected.', 0),
+			7 => array('TICKET_PRODUCT_CATEGORY', 'chaine', 0, 'The category of product that is being used for ticket accounting', 0)
 		);
 
 

--- a/htdocs/core/modules/modWorkflow.class.php
+++ b/htdocs/core/modules/modWorkflow.class.php
@@ -92,7 +92,8 @@ class modWorkflow extends DolibarrModules
 			6=>array('WORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_SUPPLIER_ORDER', 'chaine', '1', 'WORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_SUPPLIER_ORDER', 0, 'current', 0),
 			7=>array('WORKFLOW_BILL_ON_RECEPTION', 'chaine', '1', 'WORKFLOW_BILL_ON_RECEPTION', 0, 'current', 0),
 			8=>array('WORKFLOW_TICKET_LINK_CONTRACT', 'chaine', '0', 'Automatically link a ticket to available contracts', 0, 'current', 0),
-			9=>array('WORKFLOW_TICKET_USE_PARENT_COMPANY_CONTRACTS', 'chaine', '0', 'Search among parent companies contracts when automatically linking a ticket to available contracts', 0, 'current', 0)
+			9=>array('WORKFLOW_TICKET_USE_PARENT_COMPANY_CONTRACTS', 'chaine', '0', 'Search among parent companies contracts when automatically linking a ticket to available contracts', 0, 'current', 0),
+			10=>array('WORKFLOW_TICKET_CREATE_INTERVENTION', 'chaine', '1', 'WORKFLOW_TICKET_CREATE_INTERVENTION', 0, 'current', 0)
 		);
 
 		// Boxes

--- a/htdocs/core/modules/modWorkflow.class.php
+++ b/htdocs/core/modules/modWorkflow.class.php
@@ -90,7 +90,9 @@ class modWorkflow extends DolibarrModules
 			4=>array('WORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_ORDER', 'chaine', '1', 'WORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_ORDER', 0, 'current', 0),
 			5=>array('WORKFLOW_ORDER_CLASSIFY_BILLED_SUPPLIER_PROPOSAL', 'chaine', '1', 'WORKFLOW_ORDER_CLASSIFY_BILLED_SUPPLIER_PROPOSAL', 0, 'current', 0),
 			6=>array('WORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_SUPPLIER_ORDER', 'chaine', '1', 'WORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_SUPPLIER_ORDER', 0, 'current', 0),
-			7=>array('WORKFLOW_BILL_ON_RECEPTION', 'chaine', '1', 'WORKFLOW_BILL_ON_RECEPTION', 0, 'current', 0)
+			7=>array('WORKFLOW_BILL_ON_RECEPTION', 'chaine', '1', 'WORKFLOW_BILL_ON_RECEPTION', 0, 'current', 0),
+			8=>array('WORKFLOW_TICKET_LINK_CONTRACT', 'chaine', '0', 'Automatically link a ticket to available contracts', 0, 'current', 0),
+			9=>array('WORKFLOW_TICKET_USE_PARENT_COMPANY_CONTRACTS', 'chaine', '0', 'Search among parent companies contracts when automatically linking a ticket to available contracts', 0, 'current', 0)
 		);
 
 		// Boxes

--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -381,7 +381,31 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 					if (empty(NOLOGIN)) setEventMessage($langs->trans('TicketNoContractFoundToLink'), 'mesgs');
 				}
 			}
+
+			// Automatically create intervention
+			if (!empty($conf->ficheinter->enabled) && !empty($conf->ticket->enabled) && !empty($conf->workflow->enabled) && !empty($conf->global->WORKFLOW_TICKET_CREATE_INTERVENTION) && !empty($object->fk_soc)) {
+				$fichinter = new Fichinter($this->db);
+				$fichinter->socid = $object->fk_soc;
+				$fichinter->fk_project = $projectid;
+				$fichinter->author = $user->id;
+				$fichinter->model_pdf = 'soleil';
+				$fichinter->origin = $object->element;
+				$fichinter->origin_id = $object->id;
+				if ($object->fk_contract) $fichinter->fk_contrat = $object->fk_contract;
+
+				// Extrafields
+				$extrafields = new ExtraFields($this->db);
+				$extrafields->fetch_name_optionals_label($fichinter->table_element);
+				$array_options = $extrafields->getOptionalsFromPost($fichinter->table_element);
+				$fichinter->array_options = $array_options;
+
+				$id = $fichinter->create($user);
+				if ($id <= 0) {
+					setEventMessages($fichinter->error, null, 'errors');
+				}
+			}
 		}
+
 		return 0;
 	}
 

--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -352,7 +352,6 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			// Auto link contract
 			if (!empty($conf->contract->enabled) && !empty($conf->ticket->enabled) && !empty($conf->ficheinter->enabled) && !empty($conf->workflow->enabled) && !empty($conf->global->WORKFLOW_TICKET_LINK_CONTRACT) && !empty($conf->global->TICKET_PRODUCT_CATEGORY) && !empty($object->fk_soc)) {
-
 				$societe = new Societe($this->db);
 				$company_ids = (empty($conf->global->WORKFLOW_TICKET_USE_PARENT_COMPANY_CONTRACTS)) ? [$object->fk_soc] : $societe->getParentsForCompany($object->fk_soc, [$object->fk_soc]);
 
@@ -369,7 +368,7 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 							$object->setContract($contractid);
 							break;
 						} elseif ($number_contracts_found > 1) {
-							foreach($list as $linked_contract) {
+							foreach ($list as $linked_contract) {
 								$object->setContract($linked_contract->id);
 								// don't set '$contractid' so it is not used when creating an intervention.
 							}

--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -372,13 +372,13 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 								$object->setContract($linked_contract->id);
 								// don't set '$contractid' so it is not used when creating an intervention.
 							}
-							setEventMessage($langs->trans('TicketManyContractsLinked'), 'warnings');
+							if (empty(NOLOGIN)) setEventMessage($langs->trans('TicketManyContractsLinked'), 'warnings');
 							break;
 						}
 					}
 				}
 				if ($number_contracts_found == 0) {
-					setEventMessage($langs->trans('TicketNoContractFoundToLink'), 'mesgs');
+					if (empty(NOLOGIN)) setEventMessage($langs->trans('TicketNoContractFoundToLink'), 'mesgs');
 				}
 			}
 		}

--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -391,7 +391,7 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 				$fichinter->model_pdf = (!empty($conf->global->FICHEINTER_ADDON_PDF)) ? $conf->global->FICHEINTER_ADDON_PDF : 'soleil';
 				$fichinter->origin = $object->element;
 				$fichinter->origin_id = $object->id;
-				if ($object->fk_contract) $fichinter->fk_contrat = $object->fk_contract;
+				$fichinter->fk_contrat = $object->fk_contract;
 
 				// Extrafields
 				$extrafields = new ExtraFields($this->db);

--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -348,6 +348,41 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 			}
 		}
 
+		if ($action == 'TICKET_CREATE') {
+			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
+			// Auto link contract
+			if (!empty($conf->contract->enabled) && !empty($conf->ticket->enabled) && !empty($conf->ficheinter->enabled) && !empty($conf->workflow->enabled) && !empty($conf->global->WORKFLOW_TICKET_LINK_CONTRACT) && !empty($conf->global->TICKET_PRODUCT_CATEGORY) && !empty($object->fk_soc)) {
+
+				$societe = new Societe($this->db);
+				$company_ids = (empty($conf->global->WORKFLOW_TICKET_USE_PARENT_COMPANY_CONTRACTS)) ? [$object->fk_soc] : $societe->getParentsForCompany($object->fk_soc, [$object->fk_soc]);
+
+				$contrat = new Contrat($this->db);
+				$number_contracts_found = 0;
+				foreach ($company_ids as $company_id) {
+					$contrat->socid = $company_id;
+
+					$list = $contrat->getListOfContracts($option = 'all', $status = [Contrat::STATUS_DRAFT, Contrat::STATUS_VALIDATED], $product_categories = [$conf->global->TICKET_PRODUCT_CATEGORY], $line_status = [ContratLigne::STATUS_INITIAL, ContratLigne::STATUS_OPEN]);
+					if (is_array($list) && !empty($list)) {
+						$number_contracts_found = count($list);
+						if ($number_contracts_found == 1) {
+							$contractid = $list[0]->id;
+							$object->setContract($contractid);
+							break;
+						} elseif ($number_contracts_found > 1) {
+							foreach($list as $linked_contract) {
+								$object->setContract($linked_contract->id);
+								// don't set '$contractid' so it is not used when creating an intervention.
+							}
+							setEventMessage($langs->trans('TicketManyContractsLinked'), 'warnings');
+							break;
+						}
+					}
+				}
+				if ($number_contracts_found == 0) {
+					setEventMessage($langs->trans('TicketNoContractFoundToLink'), 'mesgs');
+				}
+			}
+		}
 		return 0;
 	}
 

--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -388,7 +388,7 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 				$fichinter->socid = $object->fk_soc;
 				$fichinter->fk_project = $projectid;
 				$fichinter->author = $user->id;
-				$fichinter->model_pdf = 'soleil';
+				$fichinter->model_pdf = (!empty($conf->global->FICHEINTER_ADDON_PDF)) ? $conf->global->FICHEINTER_ADDON_PDF : 'soleil';
 				$fichinter->origin = $object->element;
 				$fichinter->origin_id = $object->id;
 				if ($object->fk_contract) $fichinter->fk_contrat = $object->fk_contract;

--- a/htdocs/install/mysql/migration/13.0.0-14.0.0.sql
+++ b/htdocs/install/mysql/migration/13.0.0-14.0.0.sql
@@ -667,3 +667,7 @@ ALTER TABLE llx_bank_account ADD COLUMN pti_in_ctti integer DEFAULT 0 AFTER domi
 
 -- Keep the last msg sent to display warnings on ticket list
 ALTER TABLE llx_ticket ADD COLUMN date_last_msg_sent datetime AFTER date_read;
+
+-- Rename value to create ficheinter automatically ont tickets
+UPDATE llx_const SET name = 'WORKFLOW_TICKET_CREATE_INTERVENTION' WHERE name = 'TICKET_AUTO_CREATE_FICHINTER_CREATE';
+

--- a/htdocs/langs/en_US/interventions.lang
+++ b/htdocs/langs/en_US/interventions.lang
@@ -66,3 +66,5 @@ RepeatableIntervention=Template of intervention
 ToCreateAPredefinedIntervention=To create a predefined or recurring intervention, create a common intervention and convert it into intervention template
 Reopen=Reopen
 ConfirmReopenIntervention=Are you sure you want to open back the intervention <b>%s</b>?
+GenerateInter=Generate intervention
+FichinterNoContractLinked=Intervention %s has been created without a linked contract.

--- a/htdocs/langs/en_US/ticket.lang
+++ b/htdocs/langs/en_US/ticket.lang
@@ -141,6 +141,8 @@ TicketsDelayBeforeFirstAnswer=A new ticket should receive a first answer before 
 TicketsDelayBeforeFirstAnswerHelp=If a new ticket has not received an answer after this time period (in hours), an important warning icon will be displayed in the list view.
 TicketsDelayBetweenAnswers=An unresolved ticket should not be unactive during (hours):
 TicketsDelayBetweenAnswersHelp=If an unresolved ticket that has already received an answer has not had further interaction after this time period (in hours), a warning icon will be displayed in the list view.
+TicketChooseProductCategory=Product category for ticket support
+TicketChooseProductCategoryHelp=Select the product category of ticket support. This will be used to automatically link a contract to a ticket.
 
 #
 # Index & list page

--- a/htdocs/langs/en_US/ticket.lang
+++ b/htdocs/langs/en_US/ticket.lang
@@ -254,6 +254,8 @@ TicketNotCreatedFromPublicInterface=Not available. Ticket was not created from p
 ErrorTicketRefRequired=Ticket reference name is required
 TicketsDelayForFirstResponseTooLong=Too much time elapsed since ticket opening without any answer.
 TicketsDelayFromLastResponseTooLong=Too much time elapsed since last answer on this ticket.
+TicketNoContractFoundToLink=No contract was found to be automatically linked to this ticket. Please link a contract manually.
+TicketManyContractsLinked=Many contracts have been automatically linked to this ticket. Make sure to verify which should be chosen.
 
 #
 # Logs

--- a/htdocs/langs/en_US/workflow.lang
+++ b/htdocs/langs/en_US/workflow.lang
@@ -7,6 +7,7 @@ descWORKFLOW_PROPAL_AUTOCREATE_ORDER=Automatically create a sales order after a 
 descWORKFLOW_PROPAL_AUTOCREATE_INVOICE=Automatically create a customer invoice after a commercial proposal is signed (the new invoice will have same amount as the proposal)
 descWORKFLOW_CONTRACT_AUTOCREATE_INVOICE=Automatically create a customer invoice after a contract is validated
 descWORKFLOW_ORDER_AUTOCREATE_INVOICE=Automatically create a customer invoice after a sales order is closed (the new invoice will have same amount as the order)
+descWORKFLOW_TICKET_CREATE_INTERVENTION=Create an intervention when opening a ticket from backend and link it to the ticket.
 # Autoclassify customer proposal or order
 descWORKFLOW_ORDER_CLASSIFY_BILLED_PROPAL=Classify linked source proposal as billed when sales order is set to billed (and if the amount of the order is the same as the total amount of the signed linked proposal)
 descWORKFLOW_INVOICE_CLASSIFY_BILLED_PROPAL=Classify linked source proposal as billed when customer invoice is validated (and if the amount of the invoice is the same as the total amount of the signed linked proposal)

--- a/htdocs/langs/en_US/workflow.lang
+++ b/htdocs/langs/en_US/workflow.lang
@@ -17,9 +17,14 @@ descWORKFLOW_ORDER_CLASSIFY_SHIPPED_SHIPPING=Classify linked source sales order 
 descWORKFLOW_ORDER_CLASSIFY_BILLED_SUPPLIER_PROPOSAL=Classify linked source vendor proposal as billed when vendor invoice is validated (and if the amount of the invoice is the same as the total amount of the linked proposal)
 descWORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_SUPPLIER_ORDER=Classify linked source purchase order as billed when vendor invoice is validated (and if the amount of the invoice is the same as the total amount of the linked order)
 descWORKFLOW_BILL_ON_RECEPTION=Classify receptions to "billed" when a linked supplier order is validated
+# Automatically link ticket to contract
+descWORKFLOW_TICKET_LINK_CONTRACT=When creating a ticket, link available contracts of matching thirdparty
+descWORKFLOW_TICKET_USE_PARENT_COMPANY_CONTRACTS=When linking contracts, search among those of parents companies
 # Autoclose intervention
 descWORKFLOW_TICKET_CLOSE_INTERVENTION=Close all interventions linked to the ticket when a ticket is closed 
 AutomaticCreation=Automatic creation
 AutomaticClassification=Automatic classification
 # Autoclassify shipment
 descWORKFLOW_SHIPPING_CLASSIFY_CLOSED_INVOICE=Classify linked source shipment as closed when customer invoice is validated
+AutomaticClosing=Automatic closing
+AutomaticLinking=Automatic linking

--- a/htdocs/langs/fr_FR/interventions.lang
+++ b/htdocs/langs/fr_FR/interventions.lang
@@ -66,3 +66,4 @@ RepeatableIntervention=Modèle d'intervention
 ToCreateAPredefinedIntervention=Pour créer une intervention prédéfinie ou récurrente, créez une intervention standard et convertissez-la en modèle d'intervention
 ConfirmReopenIntervention=Êtes-vous sur de vouloir ré-ouvrir l'intervention <b>%s</b> ?
 GenerateInter=Générer intervention
+FichinterNoContractLinked=L'intervention %s a été créée avec un contrat lié.

--- a/htdocs/langs/fr_FR/ticket.lang
+++ b/htdocs/langs/fr_FR/ticket.lang
@@ -139,6 +139,8 @@ TicketPublicNotificationNewMessageDefaultEmailHelp=Envoyez un email à cette adr
 TicketsAutoNotifyClose=Envoyer un courriel de notification aux contacts à la cloture du ticket.
 TicketsAutoNotifyCloseHelp=A la cloture de tickets, vous pouvez envoyer des emails de notification aux contacts du ticket. Cette option sélectionne par défaut "tous les contacts".
 TicketWrongContact=Le contact n'est pas lié au ticket. L'email n'a pas été envoyé.
+TicketChooseProductCategory=Catégorie du produit pour la consommation de tickets
+TicketChooseProductCategoryHelp=Sélectionnez le type de produit pour la consommation de tickets. Cette information sera utilisée pour lier des contrats automatiquement aux tickets.
 
 #
 # Index & list page
@@ -250,6 +252,8 @@ TicketNotNotifyTiersAtClose=Aucun contact lié
 Unread=Non lu
 TicketNotCreatedFromPublicInterface=Non disponible. Le ticket n’a pas été créé à partir de l'interface publique.
 ErrorTicketRefRequired=La référence du ticket est requise
+TicketNoContractFoundToLink=Aucun contrat n'a été trouvé. Veuillez lier un contrat à ce ticket manuellement.
+TicketManyContractsLinked=Plusieurs contrats ont été liés à ce ticket. Veuillez choisir celui qui doit être utilisé.
 
 #
 # Logs

--- a/htdocs/langs/fr_FR/workflow.lang
+++ b/htdocs/langs/fr_FR/workflow.lang
@@ -7,6 +7,7 @@ descWORKFLOW_PROPAL_AUTOCREATE_ORDER=Créer automatiquement une commande client 
 descWORKFLOW_PROPAL_AUTOCREATE_INVOICE=Créer automatiquement une facture client à la signature d'une proposition commerciale (la facture sera du même montant que la proposition commerciale source)
 descWORKFLOW_CONTRACT_AUTOCREATE_INVOICE=Créer une facture client automatiquement à la validation d'un contrat
 descWORKFLOW_ORDER_AUTOCREATE_INVOICE=Créer automatiquement une facture client à la cloture d'un commande (la facture sera du même montant que la commande)
+descWORKFLOW_TICKET_CREATE_INTERVENTION=Créer une intervention lorsqu'un ticket est créé du backent, et la lier au ticket.
 # Autoclassify customer proposal or order
 descWORKFLOW_ORDER_CLASSIFY_BILLED_PROPAL=Classer la/les proposition(s) commerciale(s) source(s) facturée(s) au classement facturé de la commande (et si le montant de la commande est le même que le total des propositions liées)
 descWORKFLOW_INVOICE_CLASSIFY_BILLED_PROPAL=Classer la/les proposition(s) commerciale(s) source facturée(s) à la validation d'une facture client (et si le montant de la facture est le même que la somme des propositions liées)
@@ -18,9 +19,18 @@ descWORKFLOW_ORDER_CLASSIFY_SHIPPED_SHIPPING_CLOSED=Classer la commande client s
 descWORKFLOW_ORDER_CLASSIFY_BILLED_SUPPLIER_PROPOSAL=Classer la ou les proposition(s) commerciale(s) fournisseur sources facturées quand une facture fournisseur est validée (et si le montant de la facture est le même que le total des propositions sources liées)
 descWORKFLOW_INVOICE_AMOUNT_CLASSIFY_BILLED_SUPPLIER_ORDER=Classer la ou les commande(s) fournisseur(s) de source(s) à facturée(s) lorsque la facture fournisseur est validée (et si le montant de la facture est le même que le montant total des commandes liées)
 descWORKFLOW_BILL_ON_RECEPTION=Classer les réceptions en "facturées" lorsqu'une commande fournisseur liée est validée
+# Automatically link ticket to contract
+descWORKFLOW_TICKET_LINK_CONTRACT=A la création d'un ticket, lier les contrats disponibles du tiers.
+descWORKFLOW_TICKET_USE_PARENT_COMPANY_CONTRACTS=Lors du lien automatique des contrats, chercher parmi les contrats des entreprises maisons-mères.
 # Autoclose intervention
 descWORKFLOW_TICKET_CLOSE_INTERVENTION=Fermer toutes les interventions liées au ticket lorsqu'un ticket est fermé
-AutomaticCreation=Création automatique
-AutomaticClassification=Classification automatique
 # Autoclassify shipment
 descWORKFLOW_SHIPPING_CLASSIFY_CLOSED_INVOICE=Classer l'expédition source liée comme fermée lorsque la facture client est validée
+
+#
+# Workflow categories
+#
+AutomaticCreation=Création automatique
+AutomaticClassification=Classification automatique
+AutomaticClosing=Automatic closing
+AutomaticLinking=Automatic linking

--- a/htdocs/langs/fr_FR/workflow.lang
+++ b/htdocs/langs/fr_FR/workflow.lang
@@ -7,7 +7,7 @@ descWORKFLOW_PROPAL_AUTOCREATE_ORDER=Créer automatiquement une commande client 
 descWORKFLOW_PROPAL_AUTOCREATE_INVOICE=Créer automatiquement une facture client à la signature d'une proposition commerciale (la facture sera du même montant que la proposition commerciale source)
 descWORKFLOW_CONTRACT_AUTOCREATE_INVOICE=Créer une facture client automatiquement à la validation d'un contrat
 descWORKFLOW_ORDER_AUTOCREATE_INVOICE=Créer automatiquement une facture client à la cloture d'un commande (la facture sera du même montant que la commande)
-descWORKFLOW_TICKET_CREATE_INTERVENTION=Créer une intervention lorsqu'un ticket est créé du backent, et la lier au ticket.
+descWORKFLOW_TICKET_CREATE_INTERVENTION=Créer une intervention lorsqu'un ticket est créé, et la lier au ticket.
 # Autoclassify customer proposal or order
 descWORKFLOW_ORDER_CLASSIFY_BILLED_PROPAL=Classer la/les proposition(s) commerciale(s) source(s) facturée(s) au classement facturé de la commande (et si le montant de la commande est le même que le total des propositions liées)
 descWORKFLOW_INVOICE_CLASSIFY_BILLED_PROPAL=Classer la/les proposition(s) commerciale(s) source facturée(s) à la validation d'une facture client (et si le montant de la facture est le même que la somme des propositions liées)

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -3407,6 +3407,37 @@ class Societe extends CommonObject
 		}
 	}
 
+	/**
+	 *	Get parents for company
+	 *
+	 * @param   int         $company_id     ID of company to search parent
+	 * @param   array       $parents        List of companies ID found
+	 * @return	array
+	 */
+	public function getParentsForCompany($company_id, $parents = [])
+	{
+		global $langs;
+
+		if ($company_id > 0) {
+			$sql = "SELECT parent FROM " . MAIN_DB_PREFIX . "societe WHERE rowid = $company_id";
+			$resql = $this->db->query($sql);
+			if ($resql) {
+				if ($obj = $this->db->fetch_object($resql)) {
+					$parent = $obj->parent;
+					if ($parent > 0 && !in_array($parent, $parents)) {
+						$parents[] = $parent;
+						return $this->getParentsForCompany($parent, $parents);
+					} else {
+						return $parents;
+					}
+				}
+				$this->db->free($resql);
+			} else {
+				setEventMessage($langs->trans('GetCompanyParentsError', $this->db->lasterror()), 'errors');
+			}
+		}
+	}
+
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
 	 *  Returns if a profid sould be verified to be unique

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -231,22 +231,6 @@ if (empty($reshook)) {
 					$object->add_contact($user->id, "SUPPORTTEC", 'internal');
 				}
 
-				// Auto assign contrat
-				$contractid = 0;
-				if (!empty($conf->global->TICKET_AUTO_ASSIGN_CONTRACT_CREATE)) {
-					$contrat = new Contrat($db);
-					$contrat->socid = $object->fk_soc;
-					$list = $contrat->getListOfContracts();
-
-					if (is_array($list) && !empty($list)) {
-						if (count($list) == 1) {
-							$contractid = $list[0]->id;
-							$object->setContract($contractid);
-						} else {
-						}
-					}
-				}
-
 				// Auto create fiche intervention
 				if (!empty($conf->global->TICKET_AUTO_CREATE_FICHINTER_CREATE)) {
 					$fichinter = new Fichinter($db);
@@ -268,6 +252,7 @@ if (empty($reshook)) {
 						setEventMessages($fichinter->error, null, 'errors');
 					}
 				}
+
 			}
 
 			if (!$error) {

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -236,7 +236,7 @@ if (empty($reshook)) {
 					$fichinter = new Fichinter($db);
 					$fichinter->socid = $object->fk_soc;
 					$fichinter->fk_project = $projectid;
-					$fichinter->fk_contrat = $contractid;
+					$fichinter->fk_contrat = $object->fk_contract;
 					$fichinter->author = $user->id;
 					$fichinter->model_pdf = 'soleil';
 					$fichinter->origin = $object->element;

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -230,28 +230,6 @@ if (empty($reshook)) {
 					$result = $object->assignUser($user, $user->id, 1);
 					$object->add_contact($user->id, "SUPPORTTEC", 'internal');
 				}
-
-				// Auto create fiche intervention
-				if (!empty($conf->global->TICKET_AUTO_CREATE_FICHINTER_CREATE)) {
-					$fichinter = new Fichinter($db);
-					$fichinter->socid = $object->fk_soc;
-					$fichinter->fk_project = $projectid;
-					$fichinter->fk_contrat = $object->fk_contract;
-					$fichinter->author = $user->id;
-					$fichinter->model_pdf = 'soleil';
-					$fichinter->origin = $object->element;
-					$fichinter->origin_id = $object->id;
-
-					// Extrafields
-					$extrafields->fetch_name_optionals_label($fichinter->table_element);
-					$array_options = $extrafields->getOptionalsFromPost($fichinter->table_element);
-					$fichinter->array_options = $array_options;
-
-					$id = $fichinter->create($user);
-					if ($id <= 0) {
-						setEventMessages($fichinter->error, null, 'errors');
-					}
-				}
 			}
 
 			if (!$error) {

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -252,7 +252,6 @@ if (empty($reshook)) {
 						setEventMessages($fichinter->error, null, 'errors');
 					}
 				}
-
 			}
 
 			if (!$error) {


### PR DESCRIPTION
On ticket module, the option TICKET_AUTO_CREATE_FICHINTER_CREATE does not have any effect on tickets created from backend. See issue https://github.com/Dolibarr/dolibarr/issues/20391

This PR:

  -  fixes this issue by moving the ficheinter creation from ticket/card.php to triggers
  -  moves the option from the Ticket module to the Workflow module
  -  should be merged after https://github.com/Easya-Solutions/dolibarr/pull/56 that deals with ticket->contract automatic link