### PR TITLE
fix bank field missing

### DIFF
--- a/htdocs/install/mysql/migration/13.0.0-14.0.0.sql
+++ b/htdocs/install/mysql/migration/13.0.0-14.0.0.sql
@@ -657,3 +657,5 @@ ALTER TABLE llx_propaldet ADD COLUMN import_key varchar(14);
 
 -- Easya 2022.5 -> 2022.6
 ALTER TABLE llx_ticket ADD COLUMN date_last_msg_sent datetime AFTER date_read;
+
+ALTER TABLE llx_bank_account ADD COLUMN pti_in_ctti smallint DEFAULT 0 AFTER domiciliation;


### PR DESCRIPTION
Don't  know why but there is in 2022.5 a new field in table llx_bank_account (and in class htdocs/compta/bank/class/account.class.php) 
The field is in llx_bank_account.sql but missing into migration script 13.0.0-14.0.0.sql