### PR TITLE
FIX replenish and manage product stock by warhouse (PR #20605)

### DIFF
--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -904,10 +904,10 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 		}
 
 		// Desired stock
-		print '<td class="right">'.($fk_entrepot > 0 ? $desiredstockwarehouse : $desiredstock).'</td>';
+		print '<td class="right">'.((!empty($conf->global->STOCK_ALLOW_ADD_LIMIT_STOCK_BY_WAREHOUSE) && $fk_entrepot > 0) > 0 ? $desiredstockwarehouse : $desiredstock).'</td>';
 
 		// Limit stock for alert
-		print '<td class="right">'.($fk_entrepot > 0 ? $alertstockwarehouse : $alertstock).'</td>';
+		print '<td class="right">'.((!empty($conf->global->STOCK_ALLOW_ADD_LIMIT_STOCK_BY_WAREHOUSE) && $fk_entrepot > 0) > 0 ? $alertstockwarehouse : $alertstock).'</td>';
 
 		// Current stock (all warehouses)
 		print '<td class="right">'.$warning.$stock;
@@ -923,7 +923,7 @@ while ($i < ($limit ? min($num, $limit) : $num)) {
 		print '<td class="right"><a href="replenishorders.php?search_product='.$prod->id.'">'.$ordered.'</a> '.$picto.'</td>';
 
 		// To order
-		print '<td class="right"><input type="text" size="4" name="tobuy'.$i.'" value="'.($fk_entrepot > 0 ? $stocktobuywarehouse : $stocktobuy).'"></td>';
+		print '<td class="right"><input type="text" size="4" name="tobuy'.$i.'" value="'.((!empty($conf->global->STOCK_ALLOW_ADD_LIMIT_STOCK_BY_WAREHOUSE) && $fk_entrepot > 0) > 0 ? $stocktobuywarehouse : $stocktobuy).'"></td>';
 
 		// Supplier
 		print '<td class="right">';


### PR DESCRIPTION
FIX replenish and manage product stock by warhouse

When the const "STOCK_ALLOW_ADD_LIMIT_STOCK_BY_WAREHOUSE" is disabled and "multi-company" plugin is enabled, you have in replenishment link : 
![image](https://user-images.githubusercontent.com/45359511/162734598-bf83ae72-e58c-4f38-85f7-6477a1831370.png)
- no qty to order

Howerver, on product card we defined : 
- desired stock
- alert stock
![image](https://user-images.githubusercontent.com/45359511/162735242-ef944888-d35b-4d4c-ab56-a274592e8016.png)


After, with this fix, : 
![image](https://user-images.githubusercontent.com/45359511/162734460-b7580a39-7753-4176-9e87-c97ea5ad51a8.png)
- we have a quanity to order (desired stock and alert stock are positive and used in compute rule)
