### PR TITLE
fix: Ticket extrafields values are not kept when sending an email on ticket creation (#20684)

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -487,15 +487,6 @@ class Ticket extends CommonObject
 
 			if (!$error) {
 				$this->id = $this->db->last_insert_id(MAIN_DB_PREFIX."ticket");
-
-				if (!$notrigger) {
-					// Call trigger
-					$result = $this->call_trigger('TICKET_CREATE', $user);
-					if ($result < 0) {
-						$error++;
-					}
-					// End call triggers
-				}
 			}
 
 			//Update extrafield
@@ -504,6 +495,15 @@ class Ticket extends CommonObject
 				if ($result < 0) {
 					$error++;
 				}
+			}
+
+			if (!$error && !$notrigger) {
+				// Call trigger
+				$result = $this->call_trigger('TICKET_CREATE', $user);
+				if ($result < 0) {
+					$error++;
+				}
+				// End call triggers
 			}
 
 			// Commit or rollback


### PR DESCRIPTION
# Fix : Ticket extrafields values are not kept when sending an email

the $object->fetch() resets the $object->array_options property.
We must save it and replace in the newly fetched object.

This fixes the problem with 'ticket_decompt' not being saved when creating a ticket.

DLB PR #20684

