### PR TITLE
allow to modify invoices that have been validated in the past

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -286,7 +286,7 @@ if (empty($reshook)) {
 		$object->fetch($id);
 
 		if (!empty($conf->global-> INVOICE_CHECK_POSTERIOR_DATE)) {
-			$last_of_type = $object->willBeLastOfSameType();
+			$last_of_type = $object->willBeLastOfSameType($allow_validated_drafts = true);
 			if (empty($object->date_validation) && !$last_of_type[0]) {
 				setEventMessages($langs->transnoentities("ErrorInvoiceIsNotLastOfSameType", $object->ref , dol_print_date($object->date, 'day'), dol_print_date($last_of_type[1], 'day')), null, 'errors');
 				header('Location: '.$_SERVER["PHP_SELF"].'?facid='.$id);


### PR DESCRIPTION
fix: allow to modify validated invoices when INVOICE_CHECK_POSTERIOR_DATE is active

When INVOICE_CHECK_POSTERIOR_DATE is active, draft invoices can't be validated if their invoice date is posterior to the date of last invoice of same type. This avoids mistakes.

However, this forbids the modification of already validated invoices.

#20864 