### PR TITLE
Fixed an error when a supplier deposit is used to pay the supplier invoice #21171

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -159,10 +159,6 @@ abstract class CommonInvoice extends CommonObject
 	 */
 	public function getSumDepositsUsed($multicurrency = 0)
 	{
-		if ($this->element == 'facture_fourn' || $this->element == 'invoice_supplier') {
-			// TODO
-			return 0.0;
-		}
 
 		require_once DOL_DOCUMENT_ROOT.'/core/class/discount.class.php';
 


### PR DESCRIPTION
When a supplier requests a deposit, it is paid and transformed into an exceptional discount.
When you use this discount to pay all or part of the supplier's invoice, it is not deducted from the amount remaining due on the invoice.