### PR TITLE
NEW add attached file in presend email form of thirdparty (PR #21297)

### DIFF
--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -40,14 +40,16 @@ if ($action == 'presend') {
 
 	$object->fetch_projet();
 
-	if (!in_array($object->element, array('societe', 'user', 'member'))) {
+	$ref = dol_sanitizeFileName($object->ref);
+	if (!in_array($object->element, array('user', 'member'))) {
 		// TODO get also the main_lastdoc field of $object. If not found, try to guess with following code
 
-		$ref = dol_sanitizeFileName($object->ref);
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 		// Special case
 		if ($object->element == 'invoice_supplier') {
 			$fileparams = dol_most_recent_file($diroutput.'/'.get_exdir($object->id, 2, 0, 0, $object, $object->element).$ref, preg_quote($ref, '/').'([^\-])+');
+		} elseif ($object->element == 'societe') {
+			$fileparams = dol_most_recent_file($diroutput.'/'.$ref);
 		} else {
 			$fileparams = dol_most_recent_file($diroutput.'/'.$ref, preg_quote($ref, '/').'[^\-]+');
 		}
@@ -81,10 +83,13 @@ if ($action == 'presend') {
 
 	// Build document if it not exists
 	$forcebuilddoc = true;
-	if (in_array($object->element, array('societe', 'user', 'member'))) {
+	if (in_array($object->element, array('user', 'member'))) {
 		$forcebuilddoc = false;
 	}
 	if ($object->element == 'invoice_supplier' && empty($conf->global->INVOICE_SUPPLIER_ADDON_PDF)) {
+		$forcebuilddoc = false;
+	}
+	if ($object->element == 'societe' && empty($conf->global->COMPANY_ADDON_PDF)) {
 		$forcebuilddoc = false;
 	}
 	if ($forcebuilddoc) {    // If there is no default value for supplier invoice, we do not generate file, even if modelpdf was set by a manual generation
@@ -96,6 +101,8 @@ if ($action == 'presend') {
 			}
 			if ($object->element == 'invoice_supplier') {
 				$fileparams = dol_most_recent_file($diroutput.'/'.get_exdir($object->id, 2, 0, 0, $object, $object->element).$ref, preg_quote($ref, '/').'([^\-])+');
+			} elseif ($object->element == 'societe') {
+				$fileparams = dol_most_recent_file($diroutput.'/'.$ref);
 			} else {
 				$fileparams = dol_most_recent_file($diroutput.'/'.$ref, preg_quote($ref, '/').'[^\-]+');
 			}

--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -48,8 +48,6 @@ if ($action == 'presend') {
 		// Special case
 		if ($object->element == 'invoice_supplier') {
 			$fileparams = dol_most_recent_file($diroutput.'/'.get_exdir($object->id, 2, 0, 0, $object, $object->element).$ref, preg_quote($ref, '/').'([^\-])+');
-		} elseif ($object->element == 'societe') {
-			$fileparams = dol_most_recent_file($diroutput.'/'.$ref);
 		} else {
 			$fileparams = dol_most_recent_file($diroutput.'/'.$ref, preg_quote($ref, '/').'[^\-]+');
 		}
@@ -101,8 +99,6 @@ if ($action == 'presend') {
 			}
 			if ($object->element == 'invoice_supplier') {
 				$fileparams = dol_most_recent_file($diroutput.'/'.get_exdir($object->id, 2, 0, 0, $object, $object->element).$ref, preg_quote($ref, '/').'([^\-])+');
-			} elseif ($object->element == 'societe') {
-				$fileparams = dol_most_recent_file($diroutput.'/'.$ref);
 			} else {
 				$fileparams = dol_most_recent_file($diroutput.'/'.$ref, preg_quote($ref, '/').'[^\-]+');
 			}


### PR DESCRIPTION
NEW add attached file in presend email form of thirdparty card

When you set an email template and you want to add an attached file : 
![image](https://user-images.githubusercontent.com/45359511/174047982-19a0d608-769d-4207-a6ec-1ff5162a81bf.png)

When you apply this template in presend email form of thirparty card, you have the last generated file automatically attached : 
![image](https://user-images.githubusercontent.com/45359511/174048442-1cce59ee-af5d-43ab-9221-f2527fcd9677.png)
