### PR TITLE
send formconfirm as a POST

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -4960,7 +4960,7 @@ class Form
 								var post = $.post(
 									pageyes,
 									options,
-									() => {location.assign(page)}
+									(data) => {$("body").html(data)}
 								);
 							}
                             $(this).dialog("close");
@@ -4985,7 +4985,7 @@ class Form
 								var post = $.post(
 									pageno,
 									options,
-									() => {location.assign(page)}
+									(data) => {$("body").html(data)}
 								);
 							}
                             $(this).dialog("close");

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -4934,8 +4934,9 @@ class Form
                     closeOnEscape: false,
                     buttons: {
                         "'.dol_escape_js($langs->transnoentities("Yes")).'": function() {
-                        	var options = "&token='.urlencode(newToken()).'";
+							var options = "token='.urlencode(newToken()).'";
                         	var inputok = '.json_encode($inputok).';	/* List of fields into form */
+							var page = "'.dol_escape_js(!empty($page) ? $page : '').'";
                          	var pageyes = "'.dol_escape_js(!empty($pageyes) ? $pageyes : '').'";
                          	if (inputok.length>0) {
                          		$.each(inputok, function(i, inputname) {
@@ -4952,12 +4953,21 @@ class Form
                          			options += "&" + inputname + "=" + encodeURIComponent(inputvalue);
                          		});
                          	}
-                         	var urljump = pageyes + (pageyes.indexOf("?") < 0 ? "?" : "") + options;
-            				if (pageyes.length > 0) { location.href = urljump; }
+							if (pageyes.length > 0) {
+								console.log(page);
+								console.log(pageyes);
+								console.log(options);
+								var post = $.post(
+									pageyes,
+									options,
+									() => {location.assign(page)}
+								);
+							}
                             $(this).dialog("close");
                         },
                         "'.dol_escape_js($langs->transnoentities("No")).'": function() {
-                        	var options = "&token='.urlencode(newToken()).'";
+							//var options = "&token='.urlencode(newToken()).'";
+                        	var options = "token='.urlencode(newToken()).'";
                          	var inputko = '.json_encode($inputko).';	/* List of fields into form */
                          	var pageno="'.dol_escape_js(!empty($pageno) ? $pageno : '').'";
                          	if (inputko.length>0) {
@@ -4969,9 +4979,15 @@ class Form
                          			options += "&" + inputname + "=" + encodeURIComponent(inputvalue);
                          		});
                          	}
-                         	var urljump=pageno + (pageno.indexOf("?") < 0 ? "?" : "") + options;
-                         	//alert(urljump);
-            				if (pageno.length > 0) { location.href = urljump; }
+							if (pageno.length > 0) {
+								console.log(pageno);
+								console.log(options);
+								var post = $.post(
+									pageno,
+									options,
+									() => {location.assign(page)}
+								);
+							}
                             $(this).dialog("close");
                         }
                     }


### PR DESCRIPTION
Form::formconfirm() would send form inputs as GET parameters.
This would:
- set the CSRF token in the URL
- prevent some usages of this function by modules (ex. rich text editors)

#21470