### PR TITLE
2022.5.1 fix check batch on reception

### DIFF
--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -850,6 +850,23 @@ class Reception extends CommonObject
 			}
 		}
 
+		// Check batch is set
+		$product = new Product($this->db);
+		$product->fetch($fk_product);
+		if (!empty($conf->productbatch->enabled)) {
+			$langs->load("errors");
+			if (!empty($product->status_batch) && empty($batch)) {
+				$this->error = $langs->trans('ErrorProductNeedBatchNumber', $product->ref);
+				setEventMessages($this->error, $this->errors, 'errors');
+				return -1;
+			} elseif (empty($product->status_batch) && !empty($batch)) {
+				$this->error = $langs->trans('ErrorProductDoesNotNeedBatchNumber', $product->ref);
+				setEventMessages($this->error, $this->errors, 'errors');
+				return -1;
+			}
+		}
+		unset ($product);
+
 		// extrafields
 		$line->array_options = $supplierorderline->array_options;
 		if (empty($conf->global->MAIN_EXTRAFIELDS_DISABLED) && is_array($array_options) && count($array_options) > 0) {

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -856,12 +856,10 @@ class Reception extends CommonObject
 		if (!empty($conf->productbatch->enabled)) {
 			$langs->load("errors");
 			if (!empty($product->status_batch) && empty($batch)) {
-				$this->error = $langs->trans('ErrorProductNeedBatchNumber', $product->ref);
-				setEventMessages($this->error, $this->errors, 'errors');
+				$this->errors[] = $langs->trans('ErrorProductNeedBatchNumber', $product->ref);
 				return -1;
 			} elseif (empty($product->status_batch) && !empty($batch)) {
-				$this->error = $langs->trans('ErrorProductDoesNotNeedBatchNumber', $product->ref);
-				setEventMessages($this->error, $this->errors, 'errors');
+				$this->errors[] = $langs->trans('ErrorProductDoesNotNeedBatchNumber', $product->ref);
 				return -1;
 			}
 		}


### PR DESCRIPTION
# FIX Check batch on reception

When Batch module is enabled and products need a batch number, batches are not checked in Reception::addline().
This allows to create receptions with empty batches.
This PR fixes this behavior.

#21482