### PR TITLE
Product supplier price: autofill default supplier VAT

### DIFF
--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -528,46 +528,45 @@ if ($id > 0 || $ref) {
 							print ' - <a href="'.DOL_URL_ROOT.'/societe/card.php?action=create&type=f&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id.'&action='.$action).'">'.$langs->trans("CreateDolibarrThirdPartySupplier").'</a>';
 						}
 					}
+					print '<script type="text/javascript">
+					$(document).ready(function () {
+						$("#search_id_fourn").change(load_vat)
+						console.log("Requesting default VAT rate for the supplier...")
+					});
+					function load_vat() {
+						// get soc id
+						let socid = $("#id_fourn")[0].value
+	
+						// load available VAT rates
+						let vat_url = "'.dol_buildpath('/core/ajax/vatrates.php', 1).'"
+						//Make GET request with params 
+						let options = "";
+						options += "id=" + socid
+						options += "&htmlname=tva_tx"
+						options += "&action=default" // not defined in vatrates.php, default behavior.
+	
+						var get = $.getJSON(
+							vat_url,
+							options,
+							(data) => {
+								rate_options = $.parseHTML(data.value)
+								rate_options.forEach(opt => {
+									if (opt.selected) {
+										replaceVATWithSupplierValue(opt.value)
+										return
+									}
+								})
+							}
+						);
+	
+					}
+					function replaceVATWithSupplierValue(vat_rate) {
+						console.log("Default VAT rate for the supplier: " + vat_rate + "%")
+						$("[name=\'tva_tx\']")[0].value = vat_rate;
+					}
+				</script>';
 				}
 				print '</td></tr>';
-
-				print '<script type="text/javascript">
-				$(document).ready(function () {
-					$("#search_id_fourn").change(load_vat)
-					console.log("Requesting default VAT rate for the supplier...")
-				});
-				function load_vat() {
-					// get soc id
-					let socid = $("#id_fourn")[0].value
-
-					// load available VAT rates
-					let vat_url = "'.dol_buildpath('/core/ajax/vatrates.php', 1).'"
-					//Make GET request with params 
-					let options = "";
-					options += "id=" + socid
-					options += "&htmlname=tva_tx"
-					options += "&action=default" // not defined in vatrates.php, default behavior.
-
-					var get = $.getJSON(
-						vat_url,
-						options,
-						(data) => {
-							rate_options = $.parseHTML(data.value)
-							rate_options.forEach(opt => {
-								if (opt.selected) {
-									replaceVATWithSupplierValue(opt.value)
-									return
-								}
-							})
-						}
-					);
-
-				}
-				function replaceVATWithSupplierValue(vat_rate) {
-					console.log("Default VAT rate for the supplier: " + vat_rate + "%")
-					$("[name=\'tva_tx\']")[0].value = vat_rate;
-				}
-			</script>';
 
 				// Ref supplier
 				print '<tr><td class="fieldrequired">'.$langs->trans("SupplierRef").'</td><td>';

--- a/htdocs/product/fournisseurs.php
+++ b/htdocs/product/fournisseurs.php
@@ -531,6 +531,44 @@ if ($id > 0 || $ref) {
 				}
 				print '</td></tr>';
 
+				print '<script type="text/javascript">
+				$(document).ready(function () {
+					$("#search_id_fourn").change(load_vat)
+					console.log("Requesting default VAT rate for the supplier...")
+				});
+				function load_vat() {
+					// get soc id
+					let socid = $("#id_fourn")[0].value
+
+					// load available VAT rates
+					let vat_url = "'.dol_buildpath('/core/ajax/vatrates.php', 1).'"
+					//Make GET request with params 
+					let options = "";
+					options += "id=" + socid
+					options += "&htmlname=tva_tx"
+					options += "&action=default" // not defined in vatrates.php, default behavior.
+
+					var get = $.getJSON(
+						vat_url,
+						options,
+						(data) => {
+							rate_options = $.parseHTML(data.value)
+							rate_options.forEach(opt => {
+								if (opt.selected) {
+									replaceVATWithSupplierValue(opt.value)
+									return
+								}
+							})
+						}
+					);
+
+				}
+				function replaceVATWithSupplierValue(vat_rate) {
+					console.log("Default VAT rate for the supplier: " + vat_rate + "%")
+					$("[name=\'tva_tx\']")[0].value = vat_rate;
+				}
+			</script>';
+
 				// Ref supplier
 				print '<tr><td class="fieldrequired">'.$langs->trans("SupplierRef").'</td><td>';
 				if ($rowid) {


### PR DESCRIPTION
On product supplier price creation, when one chooses a supplier, the default VAT rate is not updated.
This PR adds an AJAX call to update the VAT rate matching the suppliers rate.

#21992