### PR TITLE
NEW PR22465 move htmlPrintOnlineFooter in their own lib

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -2121,3 +2121,66 @@ function addMailingEventTypeSQL($actioncode, $objcon, $filterobj)
 		return $sql2;
 	}
 }
+
+/**
+ * Show footer of company in HTML pages
+ *
+ * @param   Societe		$fromcompany	Third party
+ * @param   Translate	$langs			Output language
+ * @return 	string[]	[line1, line2]
+ */
+function htmlPrintOnlineCompanyFooter($fromcompany, $langs)
+{
+	global $conf;
+
+	// Juridical status
+	$line1 = "";
+	if ($fromcompany->forme_juridique_code) {
+		$line1 .= ($line1 ? " - " : "").getFormeJuridiqueLabel($fromcompany->forme_juridique_code);
+	}
+	// Capital
+	if ($fromcompany->capital) {
+		$line1 .= ($line1 ? " - " : "").$langs->transnoentities("CapitalOf", $fromcompany->capital)." ".$langs->transnoentities("Currency".$conf->currency);
+	}
+	// Prof Id 1
+	if ($fromcompany->idprof1 && ($fromcompany->country_code != 'FR' || !$fromcompany->idprof2)) {
+		$field = $langs->transcountrynoentities("ProfId1", $fromcompany->country_code);
+		if (preg_match('/\((.*)\)/i', $field, $reg)) {
+			$field = $reg[1];
+		}
+		$line1 .= ($line1 ? " - " : "").$field.": ".$fromcompany->idprof1;
+	}
+	// Prof Id 2
+	if ($fromcompany->idprof2) {
+		$field = $langs->transcountrynoentities("ProfId2", $fromcompany->country_code);
+		if (preg_match('/\((.*)\)/i', $field, $reg)) {
+			$field = $reg[1];
+		}
+		$line1 .= ($line1 ? " - " : "").$field.": ".$fromcompany->idprof2;
+	}
+
+	// Second line of company infos
+	$line2 = "";
+	// Prof Id 3
+	if ($fromcompany->idprof3) {
+		$field = $langs->transcountrynoentities("ProfId3", $fromcompany->country_code);
+		if (preg_match('/\((.*)\)/i', $field, $reg)) {
+			$field = $reg[1];
+		}
+		$line2 .= ($line2 ? " - " : "").$field.": ".$fromcompany->idprof3;
+	}
+	// Prof Id 4
+	if ($fromcompany->idprof4) {
+		$field = $langs->transcountrynoentities("ProfId4", $fromcompany->country_code);
+		if (preg_match('/\((.*)\)/i', $field, $reg)) {
+			$field = $reg[1];
+		}
+		$line2 .= ($line2 ? " - " : "").$field.": ".$fromcompany->idprof4;
+	}
+	// IntraCommunautary VAT
+	if ($fromcompany->tva_intra != '') {
+		$line2 .= ($line2 ? " - " : "").$langs->transnoentities("VATIntraShort").": ".$fromcompany->tva_intra;
+	}
+
+	return array($line1, $line2);
+}

--- a/htdocs/core/lib/payments.lib.php
+++ b/htdocs/core/lib/payments.lib.php
@@ -363,7 +363,7 @@ function getOnlinePaymentUrl($mode, $type, $ref = '', $amount = '9.99', $freetag
 
 
 /**
- * Show footer of company in HTML pages
+ * Show footer of payment in HTML pages
  *
  * @param   Societe		$fromcompany	Third party
  * @param   Translate	$langs			Output language
@@ -376,59 +376,9 @@ function htmlPrintOnlinePaymentFooter($fromcompany, $langs, $addformmessage = 0,
 {
 	global $conf;
 
-	// Juridical status
-	$line1 = "";
-	if ($fromcompany->forme_juridique_code) {
-		$line1 .= ($line1 ? " - " : "").getFormeJuridiqueLabel($fromcompany->forme_juridique_code);
-	}
-	// Capital
-	if ($fromcompany->capital) {
-		if (is_numeric($fromcompany->capital) && $fromcompany->capital > 0)	$line1 .= ($line1 ? ' - ' : '').$langs->transnoentities('CapitalOf', price($fromcompany->capital, 0, $langs, 0, 0, 0, $conf->currency));
-		else																$line1 .= ($line1 ? ' - ' : '').$langs->transnoentities('CapitalOf', $fromcompany->capital).' '.$langs->transnoentities('Currency'.$conf->currency);
-	}
-	// Second line of company infos
-	// Prof Id 1
-	if ($fromcompany->idprof1 && ($fromcompany->country_code != 'FR' || !$fromcompany->idprof2)) {
-		$field = $langs->transcountrynoentities("ProfId1", $fromcompany->country_code);
-		if (preg_match('/\((.*)\)/i', $field, $reg)) {
-			$field = $reg[1];
-		}
-		$tmpID	= dol_print_profids($langs->convToOutputCharset($fromcompany->idprof1), '1', $fromcompany->country_code);
-		$line2	.= ($line2 ? ' - ' : '').$field.' : '.$tmpID;
-	}
-	// Prof Id 2
-	if ($fromcompany->idprof2) {
-		$field = $langs->transcountrynoentities("ProfId2", $fromcompany->country_code);
-		if (preg_match('/\((.*)\)/i', $field, $reg)) {
-			$field = $reg[1];
-		}
-		$tmpID	= dol_print_profids($langs->convToOutputCharset($fromcompany->idprof2), '2', $fromcompany->country_code);
-		$line2	.= ($line2 ? ' - ' : '').$field.' : '.$tmpID;
-	}
-
-	// Prof Id 3
-	if ($fromcompany->idprof3) {
-		$field = $langs->transcountrynoentities("ProfId3", $fromcompany->country_code);
-		if (preg_match('/\((.*)\)/i', $field, $reg)) {
-			$field = $reg[1];
-		}
-		$tmpID	= dol_print_profids($langs->convToOutputCharset($fromcompany->idprof3), '3', $fromcompany->country_code);
-		$line2	.= ($line2 ? ' - ' : '').$field.' : '.$tmpID;
-	}
-	// Prof Id 4
-	if ($fromcompany->idprof4) {
-		$field = $langs->transcountrynoentities("ProfId4", $fromcompany->country_code);
-		if (preg_match('/\((.*)\)/i', $field, $reg)) {
-			$field = $reg[1];
-		}
-		$tmpID	= dol_print_profids($langs->convToOutputCharset($fromcompany->idprof4), '4', $fromcompany->country_code);
-		$line2	.= ($line2 ? ' - ' : '').$field.' : '.$tmpID;
-	}
-	// IntraCommunautary VAT
-	if ($fromcompany->tva_intra != '') {
-		$tmpID	= dol_print_profids($langs->convToOutputCharset($fromcompany->tva_intra), 'VAT', $fromcompany->country_code);
-		$line2	.= ($line2 ? ' - ' : '').$langs->transnoentities('VATIntraShort').' : '.$tmpID;
-	}
+	$lineList = htmlPrintOnlineCompanyFooter($fromcompany, $langs);
+	$line1 = $lineList[0];
+	$line2 = $lineList[1];
 
 	print '<br>';
 

--- a/htdocs/core/lib/ticket.lib.php
+++ b/htdocs/core/lib/ticket.lib.php
@@ -973,3 +973,35 @@ function getTicketActionCommEcmList($object)
 
 	return $documents;
 }
+
+/**
+ * Show footer of ticket in HTML pages
+ *
+ * @param   Societe		$fromcompany	Third party
+ * @param   Translate	$langs			Output language
+ * @return	void
+ */
+function htmlPrintOnlineTicketFooter($fromcompany, $langs)
+{
+	require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
+
+	$lineList = htmlPrintOnlineCompanyFooter($fromcompany, $langs);
+	$line1 = $lineList[0];
+	$line2 = $lineList[1];
+
+	print '<!-- htmlPrintOnlineTicketFooter -->'."\n";
+
+	print '<br>';
+
+	print '<div class="center paddingleft paddingright">'."\n";
+	print '<span style="font-size: 10px;"><br><hr>'."\n";
+	print $fromcompany->name.'<br>';
+	print $line1;
+	if (strlen($line1.$line2) > 50) {
+		print '<br>';
+	} else {
+		print ' - ';
+	}
+	print $line2;
+	print '</span></div>'."\n";
+}

--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -54,7 +54,6 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/html.formticket.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/ticket.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/payments.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
@@ -476,7 +475,7 @@ if ($action != "infos_success") {
 print '</div>';
 
 // End of page
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 1, $suffix, $object);
+htmlPrintOnlineTicketFooter($mysoc, $langs);
 
 llxFooter('', 'public');
 

--- a/htdocs/public/ticket/index.php
+++ b/htdocs/public/ticket/index.php
@@ -52,7 +52,6 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/html.formticket.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/ticket.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/payments.lib.php';
 
 // Load translation files required by the page
 $langs->loadLangs(array('companies', 'other', 'ticket', 'errors'));
@@ -90,7 +89,7 @@ print '</div>';
 print '</div>';
 
 // End of page
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 0, $suffix, $object);
+htmlPrintOnlineTicketFooter($mysoc, $langs);
 
 llxFooter('', 'public');
 

--- a/htdocs/public/ticket/list.php
+++ b/htdocs/public/ticket/list.php
@@ -47,7 +47,6 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/ticket.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/payments.lib.php';
 
 // Load translation files required by the page
 $langs->loadLangs(array("companies", "other", "ticket"));
@@ -727,7 +726,7 @@ if ($action == "view_ticketlist") {
 print "</div>";
 
 // End of page
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 0, $suffix, $object);
+htmlPrintOnlineTicketFooter($mysoc, $langs);
 
 llxFooter('', 'public');
 

--- a/htdocs/public/ticket/view.php
+++ b/htdocs/public/ticket/view.php
@@ -48,7 +48,6 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/ticket.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
-require_once DOL_DOCUMENT_ROOT.'/core/lib/payments.lib.php';
 
 // Load translation files required by the page
 $langs->loadLangs(array("companies", "other", "ticket"));
@@ -405,7 +404,7 @@ if ($action == "view_ticket" || $action == "presend" || $action == "close" || $a
 print "</div>";
 
 // End of page
-htmlPrintOnlinePaymentFooter($mysoc, $langs, 0, $suffix, $object);
+htmlPrintOnlineTicketFooter($mysoc, $langs, 0, $suffix, $object);
 
 llxFooter('', 'public');
 


### PR DESCRIPTION
NEW move htmlPrintOnlineFooter in their own lib
- htmlPrintOnlinePaymentFooter() was on ticket public interface 
and now we use htmlPrintOnlineTicketFooter() and this method is in ticket lib
- a new method is introduced htmlPrintOnlineCompanyFooter() in company lib

So on ticket public interface we use htmlPrintOnlineTickteFooter() and not htmlPrintOnlinePaymentFooter() for : 
- ticket list
- ticket view
- ticket create
- ticket index