### PR TITLE
Fix : On modification, if multientity is not enabled, the group would…

### DIFF
--- a/htdocs/user/group/card.php
+++ b/htdocs/user/group/card.php
@@ -217,8 +217,8 @@ if (empty($reshook)) {
 
 			if (!empty($conf->multicompany->enabled) && !empty($conf->global->MULTICOMPANY_TRANSVERSE_MODE)) {
 				$object->entity = 0;
-			} else {
-				$object->entity = GETPOST("entity");
+			} elseif (GETPOSTISSET("entity")) {
+				$object->entity = GETPOST("entity", "int");
 			}
 
 			$ret = $object->update();


### PR DESCRIPTION
Fix : On a group modification with no Multientity, the group would always be set to entity 0.

Backport from DLB : https://github.com/Dolibarr/dolibarr/blob/57feb24f4acd82c25fe28c8706d902335d70220f/htdocs/user/group/card.php#L219


