### PR TITLE
NEW add quantity in update keys in supplier prices import

### DIFF
--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -859,7 +859,7 @@ class modProduct extends DolibarrModules
 				));
 			}
 
-			$this->import_updatekeys_array[$r] = array('sp.fk_product'=>'ProductOrService', 'sp.ref_fourn'=>'SupplierRef', 'sp.fk_soc'=>'Supplier');
+			$this->import_updatekeys_array[$r] = array('sp.fk_product'=>'ProductOrService', 'sp.ref_fourn'=>'SupplierRef', 'sp.fk_soc'=>'Supplier', 'sp.quantity'=>"QtyMin");
 		}
 
 		if (!empty($conf->global->PRODUIT_MULTIPRICES)) {


### PR DESCRIPTION
NEW add quantity in update keys in supplier prices import
- quantity is a mandatory field to import supplier prices for products
- this field is added in update keys and can be used in order to update an import line instead of insert*

DLB : #23054