### PR TITLE
FIX fetch object in member subscription modify trigger for events

### DIFF
--- a/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
+++ b/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
@@ -713,7 +713,7 @@ class InterfaceActionsAuto extends DolibarrTriggers
 			if (!is_object($member)) {	// This should not happen
 				include_once DOL_DOCUMENT_ROOT.'/adherents/class/adherent.class.php';
 				$member = new Adherent($this->db);
-				$member->fetch($this->fk_adherent);
+				$member->fetch($object->fk_adherent);
 			}
 
 			if (empty($object->actionmsg2)) {


### PR DESCRIPTION
FIX fetch object in member subscription modify trigger for events
- uses "object" to fetch method instead of "this" that occurs errors
- it's the same in "MEMBER_SUBSCRIPTION_CREATE" trigger (see line 712)

DLB : #23069