### PR TITLE
NEW remove default percentage for event creation url

### DIFF
--- a/htdocs/bom/bom_agenda.php
+++ b/htdocs/bom/bom_agenda.php
@@ -210,7 +210,7 @@ if ($object->id > 0) {
 		if (get_class($objthirdparty) == 'Societe') {
 			$out .= '&amp;socid='.$objthirdparty->id;
 		}
-		$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '').'&amp;backtopage=1&amp;percentage=-1';
+		$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '').'&amp;backtopage=1';
 		//$out.=$langs->trans("AddAnAction").' ';
 		//$out.=img_picto($langs->trans("AddAnAction"),'filenew');
 		//$out.="</a>";

--- a/htdocs/contact/agenda.php
+++ b/htdocs/contact/agenda.php
@@ -252,7 +252,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 			if (is_object($objthirdparty) && get_class($objthirdparty) == 'Societe') {
 				$out .= '&amp;originid='.$objthirdparty->id.($objthirdparty->id > 0 ? '&amp;socid='.$objthirdparty->id : '');
 			}
-			$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '').'&amp;origin=contact&amp;originid='.$object->id.'&amp;percentage=-1&amp;backtopage='.urlencode($_SERVER['PHP_SELF'].($objcon->id > 0 ? '?id='.$objcon->id : ''));
+			$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '').'&amp;origin=contact&amp;originid='.$object->id.'&amp;backtopage='.urlencode($_SERVER['PHP_SELF'].($objcon->id > 0 ? '?id='.$objcon->id : ''));
 			$out .= '&amp;datep='.urlencode(dol_print_date(dol_now(), 'dayhourlog'));
 		}
 

--- a/htdocs/contrat/agenda.php
+++ b/htdocs/contrat/agenda.php
@@ -230,7 +230,7 @@ if ($id > 0) {
 	{
 		//$out.='<a href="'.DOL_URL_ROOT.'/comm/action/card.php?action=create';
 		if (get_class($objthirdparty) == 'Societe') $out.='&amp;socid='.$objthirdparty->id;
-		$out.=(! empty($objcon->id)?'&amp;contactid='.$objcon->id:'').'&amp;backtopage=1&amp;percentage=-1';
+		$out.=(! empty($objcon->id)?'&amp;contactid='.$objcon->id:'').'&amp;backtopage=1';
 		//$out.=$langs->trans("AddAnAction").' ';
 		//$out.=img_picto($langs->trans("AddAnAction"),'filenew');
 		//$out.="</a>";

--- a/htdocs/knowledgemanagement/knowledgerecord_agenda.php
+++ b/htdocs/knowledgemanagement/knowledgerecord_agenda.php
@@ -209,7 +209,7 @@ if ($object->id > 0) {
 		if (get_class($objthirdparty) == 'Societe') {
 			$out .= '&socid='.urlencode($objthirdparty->id);
 		}
-		$out .= (!empty($objcon->id) ? '&contactid='.urlencode($objcon->id) : '').'&percentage=-1';
+		$out .= (!empty($objcon->id) ? '&contactid='.urlencode($objcon->id) : '');
 		//$out.=$langs->trans("AddAnAction").' ';
 		//$out.=img_picto($langs->trans("AddAnAction"),'filenew');
 		//$out.="</a>";

--- a/htdocs/modulebuilder/template/myobject_agenda.php
+++ b/htdocs/modulebuilder/template/myobject_agenda.php
@@ -261,7 +261,7 @@ if ($object->id > 0) {
 		if (get_class($objthirdparty) == 'Societe') {
 			$out .= '&socid='.urlencode($objthirdparty->id);
 		}
-		$out .= (!empty($objcon->id) ? '&contactid='.urlencode($objcon->id) : '').'&percentage=-1';
+		$out .= (!empty($objcon->id) ? '&contactid='.urlencode($objcon->id) : '');
 		//$out.=$langs->trans("AddAnAction").' ';
 		//$out.=img_picto($langs->trans("AddAnAction"),'filenew');
 		//$out.="</a>";

--- a/htdocs/mrp/mo_agenda.php
+++ b/htdocs/mrp/mo_agenda.php
@@ -209,7 +209,7 @@ if ($object->id > 0) {
 		if (get_class($objthirdparty) == 'Societe') {
 			$out .= '&amp;socid='.$objthirdparty->id;
 		}
-		$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '').'&amp;backtopage=1&amp;percentage=-1';
+		$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '').'&amp;backtopage=1';
 		//$out.=$langs->trans("AddAnAction").' ';
 		//$out.=img_picto($langs->trans("AddAnAction"),'filenew');
 		//$out.="</a>";

--- a/htdocs/partnership/partnership_agenda.php
+++ b/htdocs/partnership/partnership_agenda.php
@@ -209,7 +209,7 @@ if ($object->id > 0) {
 		if (get_class($objthirdparty) == 'Societe') {
 			$out .= '&socid='.urlencode($objthirdparty->id);
 		}
-		$out .= (!empty($objcon->id) ? '&contactid='.urlencode($objcon->id) : '').'&percentage=-1';
+		$out .= (!empty($objcon->id) ? '&contactid='.urlencode($objcon->id) : '');
 		//$out.=$langs->trans("AddAnAction").' ';
 		//$out.=img_picto($langs->trans("AddAnAction"),'filenew');
 		//$out.="</a>";

--- a/htdocs/product/agenda.php
+++ b/htdocs/product/agenda.php
@@ -192,7 +192,7 @@ if ($id > 0 || $ref) {
 		if (get_class($objproduct) == 'Product') {
 			$out .= '&amp;prodid='.$objproduct->id.'&origin=product&originid='.$id;
 		}
-		$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '').'&amp;backtopage=1&amp;percentage=-1';
+		$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '').'&amp;backtopage=1';
 		//$out.=$langs->trans("AddAnAction").' ';
 		//$out.=img_picto($langs->trans("AddAnAction"),'filenew');
 		//$out.="</a>";

--- a/htdocs/recruitment/recruitmentcandidature_agenda.php
+++ b/htdocs/recruitment/recruitmentcandidature_agenda.php
@@ -238,7 +238,7 @@ if ($object->id > 0) {
 		if (get_class($objthirdparty) == 'Societe') {
 			$out .= '&amp;socid='.$objthirdparty->id;
 		}
-		$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '').'&amp;backtopage=1&amp;percentage=-1';
+		$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '').'&amp;backtopage=1';
 		//$out.=$langs->trans("AddAnAction").' ';
 		//$out.=img_picto($langs->trans("AddAnAction"),'filenew');
 		//$out.="</a>";

--- a/htdocs/recruitment/recruitmentjobposition_agenda.php
+++ b/htdocs/recruitment/recruitmentjobposition_agenda.php
@@ -237,7 +237,7 @@ if ($object->id > 0) {
 		if (get_class($objthirdparty) == 'Societe') {
 			$out .= '&amp;socid='.$objthirdparty->id;
 		}
-		$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '').'&amp;backtopage=1&amp;percentage=-1';
+		$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '').'&amp;backtopage=1';
 		//$out.=$langs->trans("AddAnAction").' ';
 		//$out.=img_picto($langs->trans("AddAnAction"),'filenew');
 		//$out.="</a>";

--- a/htdocs/societe/agenda.php
+++ b/htdocs/societe/agenda.php
@@ -152,7 +152,7 @@ if ($socid > 0) {
 		if (is_object($objthirdparty) && get_class($objthirdparty) == 'Societe') {
 			$out .= '&amp;originid='.$objthirdparty->id.($objthirdparty->id > 0 ? '&amp;socid='.$objthirdparty->id : '').'&amp;backtopage='.urlencode($_SERVER['PHP_SELF'].($objthirdparty->id > 0 ? '?socid='.$objthirdparty->id : ''));
 		}
-		$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '').'&amp;percentage=-1';
+		$out .= (!empty($objcon->id) ? '&amp;contactid='.$objcon->id : '');
 		$out .= '&amp;datep='.dol_print_date(dol_now(), 'dayhourlog');
 	}
 

--- a/htdocs/workstation/workstation_agenda.php
+++ b/htdocs/workstation/workstation_agenda.php
@@ -208,7 +208,7 @@ if ($object->id > 0) {
 		if (get_class($objthirdparty) == 'Societe') {
 			$out .= '&socid='.urlencode($objthirdparty->id);
 		}
-		$out .= (!empty($objcon->id) ? '&contactid='.urlencode($objcon->id) : '').'&percentage=-1';
+		$out .= (!empty($objcon->id) ? '&contactid='.urlencode($objcon->id) : '');
 		//$out.=$langs->trans("AddAnAction").' ';
 		//$out.=img_picto($langs->trans("AddAnAction"),'filenew');
 		//$out.="</a>";


### PR DESCRIPTION
NEW remove default percentage for event creation url
- percentage was set to -1 by default when we want to add an event from "Events" tab of a card

For example, on "events" tab of third-party card : 
![image](https://user-images.githubusercontent.com/45359511/209555214-573c0db3-4158-4fc6-a542-c659ca32270d.png)

When you click on "+" button, you have the event card in creation mode : 
![image](https://user-images.githubusercontent.com/45359511/209555274-26e108ce-c368-467e-abfd-5e6b935d3231.png)

And the default "Percentage" select field was set to -1 : 
![image](https://user-images.githubusercontent.com/45359511/209555331-c23b8c6b-abe4-4c74-be40-3dfbb87e67f6.png)

Even if a default parameter was set to "To do" in agenda setup : 
![image](https://user-images.githubusercontent.com/45359511/209555425-84f49c06-1ca6-484d-a7ed-c30d68423e96.png)

So now, we remove "percentage" value in the url of "event" tab, and when we click on "+" button we got the default parameter set in agenda setup.

DLB : #23340