### PR TITLE
FIX cancel or delete a validated shipment with kit

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -1387,15 +1387,6 @@ class Expedition extends CommonObject
 						}
 					}
 					if (empty($lotArray)) {
-						// no lot/serial
-						// We increment stock of product (and sub-products)
-						// We use warehouse selected for each line
-						$result = $mouvS->reception($user, $obj->fk_product, $obj->fk_entrepot, $obj->qty, 0, $langs->trans("ShipmentCanceledInDolibarr", $this->ref)); // Price is set to 0, because we don't want to see WAP changed
-						if ($result < 0) {
-							$error++; $this->errors = $this->errors + $mouvS->errors;
-							break;
-						}
-
 						// we try deletion of dispatched lines
 						$line_dispatch = new ExpeditionLineDispatch($this->db);
 						$res = $line_dispatch->fetchAll('', '', 0, 0, array('fk_expeditiondet' => $obj->expeditiondet_id));
@@ -1403,11 +1394,22 @@ class Expedition extends CommonObject
 							$error++; $this->errors[] = "Error ".$this->db->lasterror();
 						}
 						if (!$error) {
-							foreach ($line_dispatch->lines as $line) {
-								$result = $mouvS->reception($user, $line->fk_product, $line->fk_entrepot, $line->qty, 0, $langs->trans("ShipmentDeletedInDolibarr", $this->ref)); // Price is set to 0, because we don't want to see WAP changed
+							if (!empty($line_dispatch->lines)) {
+								foreach ($line_dispatch->lines as $line) {
+									$result = $mouvS->reception($user, $line->fk_product, $line->fk_entrepot, $line->qty, 0, $langs->trans("ShipmentCanceledInDolibarr", $this->ref)); // Price is set to 0, because we don't want to see WAP changed
+									if ($result < 0) {
+										$error++;
+										$this->errors = $this->errors + $mouvS->errors;
+										break;
+									}
+								}
+							} else {
+								// no lot/serial
+								// We increment stock of product (and sub-products)
+								// We use warehouse selected for each line
+								$result = $mouvS->reception($user, $obj->fk_product, $obj->fk_entrepot, $obj->qty, 0, $langs->trans("ShipmentCanceledInDolibarr", $this->ref)); // Price is set to 0, because we don't want to see WAP changed
 								if ($result < 0) {
-									$error++;
-									$this->errors = $this->errors + $mouvS->errors;
+									$error++; $this->errors = $this->errors + $mouvS->errors;
 									break;
 								}
 							}
@@ -1596,15 +1598,6 @@ class Expedition extends CommonObject
 						}
 					}
 					if (empty($lotArray)) {
-						// no lot/serial
-						// We increment stock of product (and sub-products)
-						// We use warehouse selected for each line
-						$result = $mouvS->reception($user, $obj->fk_product, $obj->fk_entrepot, $obj->qty, 0, $langs->trans("ShipmentDeletedInDolibarr", $this->ref)); // Price is set to 0, because we don't want to see WAP changed
-						if ($result < 0) {
-							$error++; $this->errors = $this->errors + $mouvS->errors;
-							break;
-						}
-
 						// we try deletion of dispatched lines
 						$line_dispatch = new ExpeditionLineDispatch($this->db);
 						$res = $line_dispatch->fetchAll('', '', 0, 0, array('fk_expeditiondet' => $obj->expeditiondet_id));
@@ -1612,11 +1605,22 @@ class Expedition extends CommonObject
 							$error++; $this->errors[] = "Error ".$this->db->lasterror();
 						}
 						if (!$error) {
-							foreach ($line_dispatch->lines as $line) {
-								$result = $mouvS->reception($user, $line->fk_product, $line->fk_entrepot, $line->qty, 0, $langs->trans("ShipmentDeletedInDolibarr", $this->ref)); // Price is set to 0, because we don't want to see WAP changed
+							if (!empty($line_dispatch->lines)) {
+								foreach ($line_dispatch->lines as $line) {
+									$result = $mouvS->reception($user, $line->fk_product, $line->fk_entrepot, $line->qty, 0, $langs->trans("ShipmentDeletedInDolibarr", $this->ref)); // Price is set to 0, because we don't want to see WAP changed
+									if ($result < 0) {
+										$error++;
+										$this->errors = $this->errors + $mouvS->errors;
+										break;
+									}
+								}
+							} else {
+								// no lot/serial
+								// We increment stock of product (and sub-products)
+								// We use warehouse selected for each line
+								$result = $mouvS->reception($user, $obj->fk_product, $obj->fk_entrepot, $obj->qty, 0, $langs->trans("ShipmentDeletedInDolibarr", $this->ref)); // Price is set to 0, because we don't want to see WAP changed
 								if ($result < 0) {
-									$error++;
-									$this->errors = $this->errors + $mouvS->errors;
+									$error++; $this->errors = $this->errors + $mouvS->errors;
 									break;
 								}
 							}


### PR DESCRIPTION
FIX cancel or delete a validated shipment with kit
- when you cancel or delete a validated shipment, two movements were inserted for virtual products (whose one bad movement on warehouse id = 0)
- with this fix we haven't the movement in warehouse id = 0