### PR TITLE
FIX attach file and send by mail in ticket

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1006,7 +1006,7 @@ class FormTicket
 		$langs->loadLangs(array('other', 'mails'));
 
 		// Clear temp files. Must be done at beginning, before call of triggers
-		if (GETPOST('mode', 'alpha') == 'init' || (GETPOST('modelmailselected', 'alpha') && GETPOST('modelmailselected', 'alpha') != '-1')) {
+		if (GETPOST('mode', 'alpha') == 'init' || (GETPOST('modelselected') && GETPOST('modelmailselected', 'alpha') && GETPOST('modelmailselected', 'alpha') != '-1')) {
 			$this->clear_attached_files();
 		}
 
@@ -1039,10 +1039,10 @@ class FormTicket
 		$listofmimes = array();
 		$keytoavoidconflict = empty($this->trackid) ? '' : '-'.$this->trackid; // this->trackid must be defined
 
-		if (GETPOST('mode', 'alpha') == 'init' || (GETPOST('modelmailselected', 'alpha') && GETPOST('modelmailselected', 'alpha') != '-1')) {
-			if (!empty($arraydefaultmessage->joinfiles) && is_array($this->param['fileinit'])) {
+		if (GETPOST('mode', 'alpha') == 'init' || (GETPOST('modelselected') && GETPOST('modelmailselected', 'alpha') && GETPOST('modelmailselected', 'alpha') != '-1')) {
+			if (!empty($arraydefaultmessage->joinfiles) && !empty($this->param['fileinit']) && is_array($this->param['fileinit'])) {
 				foreach ($this->param['fileinit'] as $file) {
-					$this->add_attached_files($file, basename($file), dol_mimetype($file));
+					$formmail->add_attached_files($file, basename($file), dol_mimetype($file));
 				}
 			}
 		}

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -2476,7 +2476,7 @@ class Ticket extends CommonObject
 		$maxheightmini = 72;
 
 		$formmail = new FormMail($this->db);
-
+		$formmail->trackid = 'tic'.$this->id;
 		$attachedfiles = $formmail->get_attached_files();
 
 		$filepath = $attachedfiles['paths'];


### PR DESCRIPTION
FIX attach file and send by mail in ticket

**To reproduce**
- apply a mail template
![image](https://user-images.githubusercontent.com/45359511/216610474-ee9416a8-2fa0-48c9-9815-06b3a0bd2202.png)
- and try to attach a file
![image](https://user-images.githubusercontent.com/45359511/216610597-9b67c96b-fa89-4a09-b73c-adf88be1640a.png)
- and you got a uploaded with success message but there is no attached files
- and when you add this message the mail sent has not attached files and the ticket has no linked files

**After**
- with this fix, the attached file is here : 
![image](https://user-images.githubusercontent.com/45359511/216611107-5425f3bc-cd42-4aca-bec5-d3bb10b8f111.png)
- and when you add the message : the attached file is in the email and linked to the card
