### PR TITLE
FIX substitute project variables in document with free text

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -436,10 +436,6 @@ if (!$error && $massaction == 'confirm_presend') {
 				dol_syslog("We have set an array of ".count($looparray)." emails to send. oneemailperrecipient=".$oneemailperrecipient);
 				//var_dump($oneemailperrecipient); var_dump($listofqualifiedobj); var_dump($listofqualifiedref);
 				foreach ($looparray as $objectid => $objecttmp) {		// $objecttmp is a real object or an empty object if we choose to send one email per thirdparty instead of one per object
-					// Make substitution in email content
-					if (!empty($conf->projet->enabled) && method_exists($objecttmp, 'fetch_projet') && is_null($objecttmp->project)) {
-						$objecttmp->fetch_projet();
-					}
 					$substitutionarray = getCommonSubstitutionArray($langs, 0, null, $objecttmp);
 					$substitutionarray['__ID__']    = ($oneemailperrecipient ? join(', ', array_keys($listofqualifiedobj)) : $objecttmp->id);
 					$substitutionarray['__REF__']   = ($oneemailperrecipient ? join(', ', $listofqualifiedref) : $objecttmp->ref);

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -7049,6 +7049,11 @@ function getCommonSubstitutionArray($outputlangs, $onlykey = 0, $exclude = null,
 				$substitutionarray['__RECEPTIONTRACKNUMURL__'] = 'Shipping tracking url';
 			}
 		} else {
+			// can substitute variables for project
+			if (!empty($conf->projet->enabled) && method_exists($object, 'fetch_project') && is_null($object->project)) {
+				$object->fetch_project();
+			}
+
 			$substitutionarray['__ID__'] = $object->id;
 			$substitutionarray['__REF__'] = $object->ref;
 			$substitutionarray['__LABEL__'] = (isset($object->label) ? $object->label : (isset($object->title) ? $object->title : null));


### PR DESCRIPTION
FIX substitute project variables in document with free text

**To reproduce**
When you have free text in invoice for example :
![image](https://user-images.githubusercontent.com/45359511/217229943-28e78ac8-e420-4675-9a78-98f99acace1b.png)

The generated document don't substitute project variables : 
![image](https://user-images.githubusercontent.com/45359511/217230219-90d09854-44be-43dc-8a07-e10a5101b70c.png)

**After**
I moved fetch project function in "getCommonSubstitutionArray()" in order to be able to substitute project variables (not only for mass action)
So mass action and documents use this common method and the free text is now substituted : 
![image](https://user-images.githubusercontent.com/45359511/217231223-7bc9a98e-fbdd-4013-8193-076317f38280.png)