### PR TITLE
2022.5.3 fix supplier reload page

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1631,6 +1631,7 @@ if ($action == 'create') {
 						console.log("We have changed the company - Reload page");
 						// reload page
 						$("input[name=action]").val("create");
+						$("input[name=socid]").val($("#socid").val());
 						$("form[name=add]").submit();
 					});
 				});
@@ -1660,12 +1661,12 @@ if ($action == 'create') {
 
 	// Payment term
 	print '<tr><td class="nowrap">'.$langs->trans('PaymentConditionsShort').'</td><td>';
-	$form->select_conditions_paiements(isset($_POST['cond_reglement_id']) ? $_POST['cond_reglement_id'] : $cond_reglement_id, 'cond_reglement_id');
+	$form->select_conditions_paiements(!empty($_POST['cond_reglement_id']) ? $_POST['cond_reglement_id'] : $cond_reglement_id, 'cond_reglement_id', -1, 1);
 	print '</td></tr>';
 
 	// Payment mode
 	print '<tr><td>'.$langs->trans('PaymentMode').'</td><td>';
-	$form->select_types_paiements(isset($_POST['mode_reglement_id']) ? $_POST['mode_reglement_id'] : $mode_reglement_id, 'mode_reglement_id');
+	$form->select_types_paiements(!empty($_POST['mode_reglement_id']) ? $_POST['mode_reglement_id'] : $mode_reglement_id, 'mode_reglement_id');
 	print '</td></tr>';
 
 	// Planned delivery date

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1631,7 +1631,6 @@ if ($action == 'create') {
 						console.log("We have changed the company - Reload page");
 						// reload page
 						$("input[name=action]").val("create");
-						$("input[name=socid]").val($("#socid").val());
 						$("form[name=add]").submit();
 					});
 				});


### PR DESCRIPTION
# Fix : On fourn/commande/card.php creation, supplier values were not used

When const RELOAD_PAGE_ON_SUPPLIER_CHANGE is set, the page is reloaded on supplier change.

When reloading the page on supplier change, we want to use the supplier parameters for cond_reglement_id and mode_reglement_id. This was the behavior before PR #22756. In #22756, the parameter &socid has been forgotten.

Another bug is that on a blank creation page, the value of cond_reglement_id is always set. On page reload, the value is always set, so it is not replaced by the wanted value for supplier.

example : 

before : 

1. virgin creation page : cond_reglement_id is always set
![before-1](https://user-images.githubusercontent.com/89838020/217283263-5f6ed70a-3f00-4f1b-9029-493e64b5fcd4.png)

2. after supplier selection : the supplier values have not been used
![before-2](https://user-images.githubusercontent.com/89838020/217283882-e4d86181-9a35-45bd-8415-1908f089da7f.png)



after :

1.  virgin creation page : cond_reglement_id is empty
![after-1](https://user-images.githubusercontent.com/89838020/217283374-8a9d3ef1-292f-4fc4-b44a-4fb4bc853e8e.png)

2. after supplier selection : the supplier values have been used 
![after-2](https://user-images.githubusercontent.com/89838020/217283923-c049cfa2-0569-4c9e-b2d3-38c4eb3a2772.png)



NOTE : This works only if MAIN_DEFAULT_PAYMENT_TERM_ID is not set. If MAIN_DEFAULT_PAYMENT_TERM_ID is set, the parameter cond_reglement_id will always be set on the first page.