### PR TITLE
fix: % is not required here it's already output at the end, make double %%

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -1690,7 +1690,6 @@ function pdf_getlinevatrate($object, $i, $outputlangs, $hidedetails = 0)
 			$tmpresult = '';
 
 			$tmpresult .= vatrate($object->lines[$i]->tva_tx, 0, $object->lines[$i]->info_bits, -1);
-			$tmpresult .= '%';
 			if (empty($conf->global->MAIN_PDF_MAIN_HIDE_SECOND_TAX)) {
 				if ($object->lines[$i]->total_localtax1 >= 0) {
 					/*


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1050053/219679941-b04f8e81-ac2a-45f4-ab8d-3815337b4b02.png)


