### PR TITLE
FIX backtopage url in event card

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -948,7 +948,7 @@ if ($action == 'create') {
 	print '<input type="hidden" name="donotclearsession" value="1">';
 	print '<input type="hidden" name="page_y" value="">';
 	if ($backtopage) {
-		print '<input type="hidden" name="backtopage" value="'.($backtopage != '1' ? $backtopage : htmlentities($_SERVER["HTTP_REFERER"])).'">';
+		print '<input type="hidden" name="backtopage" value="'.($backtopage != '1' ? $backtopage : '').'">';
 	}
 	if (empty($conf->global->AGENDA_USE_EVENT_TYPE)) {
 		print '<input type="hidden" name="actioncode" value="'.dol_getIdFromCode($db, 'AC_OTH', 'c_actioncomm').'">';
@@ -1454,7 +1454,7 @@ if ($id > 0) {
 		print '<input type="hidden" name="ref_ext" value="'.$object->ref_ext.'">';
 		print '<input type="hidden" name="page_y" value="">';
 		if ($backtopage) {
-			print '<input type="hidden" name="backtopage" value="'.($backtopage != '1' ? $backtopage : htmlentities($_SERVER["HTTP_REFERER"])).'">';
+			print '<input type="hidden" name="backtopage" value="'.($backtopage != '1' ? $backtopage : '').'">';
 		}
 		if (empty($conf->global->AGENDA_USE_EVENT_TYPE)) {
 			print '<input type="hidden" name="actioncode" value="'.$object->type_code.'">';


### PR DESCRIPTION
FIX backtopage url in event card :

DLB : #24041

- HTTP referer is like an external link and contains full url with protocol sush as "http://" or "https://"
- this url is not allow in GETPOST method and the protocol with "//" are removed
- see commented line 648 in core/lib/functions.lib.php 
`// We remove schema*// to remove external URL`

**To reproduce**
- go to the event tab on product card
![image](https://user-images.githubusercontent.com/45359511/221248023-4deafeba-f246-4612-b413-2f43c7d37eb4.png)
- then click on "+" button to create an event
![image](https://user-images.githubusercontent.com/45359511/221248429-ece17ce8-e2ea-43b7-98a9-d52ddf34f689.png)
- and click on cancel button of the event card in create mode
You will appear a page with error 404 for file not found
![image](https://user-images.githubusercontent.com/45359511/221250420-e0b15c3b-b550-4301-a801-762b403acf19.png)

I removed the HTTP_REFER in backtopage url in order to avoid this case, but I don't know if it's the good way to do.
Maybe, we shouldn't use "backtopage=1" in event tabs.