### PR TITLE
don't add contact from contact liste who are closed

### DIFF
--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -267,7 +267,7 @@ if ($action == 'presend') {
 	}
 
 	$contactarr = array();
-	$contactarr = $tmpobject->liste_contact(-1, 'external');
+	$contactarr = $tmpobject->liste_contact(-1, 'external', 0, '', 1);
 
 	if (is_array($contactarr) && count($contactarr) > 0) {
 		require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';


### PR DESCRIPTION
# New #24076 [*don't add contact from contact liste who are closed*]
With this change, closed contacts are no longer available in the selection list to receive emails.
need #308