### PR TITLE
FIX: validation date for invoice was compared in all entities. 

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -5588,6 +5588,7 @@ class Facture extends CommonInvoice
 		$sql .= ' FROM '.MAIN_DB_PREFIX.'facture';
 		$sql .= ' WHERE type = ' . (int) $this->type ;
 		$sql .= ' AND date_valid IS NOT NULL';
+		$sql .= " AND entity IN (".getEntity('invoice').")";
 		$sql .= ' ORDER BY datef DESC LIMIT 1';
 
 		$result = $this->db->query($sql);


### PR DESCRIPTION
https://github.com/Dolibarr/dolibarr/pull/24091

FIX : validation date for invoice was compared in all entities

When const INVOICE_CHECK_POSTERIOR_DATE is activated,
validation date for invoice were compared in all entities.

This fix compares invoice dates for invoices belonging to the same entity.