### PR TITLE
NEW adapt category and product pictures sizes on takepos

### DIFF
--- a/htdocs/takepos/css/pos.css.php
+++ b/htdocs/takepos/css/pos.css.php
@@ -254,6 +254,9 @@ div.wrapper{
 	text-align: center;
 	box-sizing: border-box;
 	background-color:#fff;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 div.wrapper2{
@@ -268,10 +271,14 @@ div.wrapper2{
 	text-align: center;
 	box-sizing: border-box;
 	background-color:#fff;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 img.imgwrapper {
 	max-width: 100%;
+	max-height: 100%;
 }
 
 button:active{

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -1178,7 +1178,7 @@ if (!empty($conf->global->TAKEPOS_WEIGHING_SCALE)) {
 					echo '<span class="fa fa-chevron-right centerinmiddle" style="font-size: 5em;"></span>';
 				} else {
 					if (!getDolGlobalString('TAKEPOS_HIDE_CATEGORY_IMAGES')) {
-						echo '<img class="imgwrapper" height="100%" id="catimg'.$count.'" />';
+						echo '<img class="imgwrapper" id="catimg'.$count.'" />';
 					}
 				}
 				?>
@@ -1220,7 +1220,7 @@ if (!empty($conf->global->TAKEPOS_WEIGHING_SCALE)) {
 							echo '<button type="button" id="probutton'.$count.'" class="productbutton" style="display: none;"></button>';
 						} else {
 							print '<div class="" id="proprice'.$count.'"></div>';
-							print '<img class="imgwrapper" height="100%" title="" id="proimg'.$count.'">';
+							print '<img class="imgwrapper" title="" id="proimg'.$count.'">';
 						}
 					}
 					?>


### PR DESCRIPTION
NEW adapt category and product pictures sizes on takepos
DLB : #24133
- categories and products pictures are not proportionally sized

**Before**
![image](https://user-images.githubusercontent.com/45359511/223116516-e4d8a614-ca08-4a89-9a0a-695a8a0ceacc.png)

**After**
![image](https://user-images.githubusercontent.com/45359511/223116048-825b8b06-ece2-4fe0-bea6-b6a9410208f6.png)

It's also works for mobile devices.