### PR TITLE
Bugfix inside selectTypesTickets function inside html.formticket.class.php

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -586,7 +586,7 @@ class FormTicket
 	{
 		global $langs, $user;
 
-		$selected = is_array($selected) ? $selected : (!empty($selected) ? implode(',', $selected) : array());
+		$selected = is_array($selected) ? $selected : (!empty($selected) ? explode(',', $selected) : array());
 		$ticketstat = new Ticket($this->db);
 
 		dol_syslog(get_class($this)."::select_types_tickets ".implode(';',$selected).", ".$htmlname.", ".$filtertype.", ".$format.", ".$multiselect, LOG_DEBUG);


### PR DESCRIPTION
# Fix [*#24291*]
change done inside this commit 5a9901e484b09a980e714200556ae5571ecfe3df for develop
`$selected = is_array($selected) ? $selected : (!empty($selected) ? implode(',', $selected) : array());`
has a problem, since implode is called when `$selected` is not an array and is not empty.
Since in this case `$selected` is a string, we should use `explode` instead of `implode` or as eldy `array($selected)`