### PR TITLE
add a hidden const to show the EF inside a public ticket view

### DIFF
--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -60,7 +60,7 @@ if ($reshook < 0) {
 
 
 //var_dump($extrafields->attributes[$object->table_element]);
-if (empty($reshook) && isset($extrafields->attributes[$object->table_element]['label']) && is_array($extrafields->attributes[$object->table_element]['label'])) {
+if (!empty($conf->global->EASYA_ONLY_SHOW_PUBLIC_TICKET_EF) && empty($reshook) && isset($extrafields->attributes[$object->table_element]['label']) && is_array($extrafields->attributes[$object->table_element]['label'])) {
 	$lastseparatorkeyfound = '';
 	$extrafields_collapse_num = '';
 	$extrafields_collapse_num_old = '';


### PR DESCRIPTION
# New
add a hidden const to show the extrafields inside a public interface view.
Link to issue send to Dolibarr: #24250
