### PR TITLE
Bugfix fetch_optionals before the line update to not lose the invisible fields

### DIFF
--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -575,7 +575,8 @@ if (empty($reshook)) {
 		// Extrafields
 		$extrafields->fetch_name_optionals_label($object->table_element_line);
 		$array_options = $extrafields->getOptionalsFromPost($object->table_element_line);
-		$objectline->array_options = $array_options;
+		$objectline->fetch_optionals();
+		$objectline->array_options = array_merge($objectline->array_options, $array_options);
 
 		$result = $objectline->update($user);
 		if ($result < 0) {

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -575,7 +575,6 @@ if (empty($reshook)) {
 		// Extrafields
 		$extrafields->fetch_name_optionals_label($object->table_element_line);
 		$array_options = $extrafields->getOptionalsFromPost($object->table_element_line);
-		$objectline->fetch_optionals();
 		$objectline->array_options = array_merge($objectline->array_options, $array_options);
 
 		$result = $objectline->update($user);

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -1437,24 +1437,28 @@ class FichinterLigne extends CommonObjectLine
 	 */
 	public function fetch($rowid)
 	{
+		dol_syslog("FichinterLigne::fetch", LOG_DEBUG);
+
 		$sql = 'SELECT ft.rowid, ft.fk_fichinter, ft.description, ft.duree, ft.rang,';
 		$sql .= ' ft.date as datei';
 		$sql .= ' FROM '.MAIN_DB_PREFIX.'fichinterdet as ft';
 		$sql .= ' WHERE ft.rowid = '.((int) $rowid);
 
-		dol_syslog("FichinterLigne::fetch", LOG_DEBUG);
-		$result = $this->db->query($sql);
-		if ($result) {
-			$objp = $this->db->fetch_object($result);
-			$this->rowid          	= $objp->rowid;
-			$this->id = $objp->rowid;
-			$this->fk_fichinter   	= $objp->fk_fichinter;
-			$this->datei = $this->db->jdate($objp->datei);
-			$this->desc           	= $objp->description;
-			$this->duration       	= $objp->duree;
-			$this->rang           	= $objp->rang;
+		$resql = $this->db->query($sql);
+		if ($resql) {
+			$objp               = $this->db->fetch_object($resql);
+			$this->rowid        = $objp->rowid;
+			$this->id           = $objp->rowid;
+			$this->fk_fichinter = $objp->fk_fichinter;
+			$this->datei        = $this->db->jdate($objp->datei);
+			$this->desc         = $objp->description;
+			$this->duration     = $objp->duree;
+			$this->rang         = $objp->rang;
 
-			$this->db->free($result);
+			$this->db->free($resql);
+
+			$this->fetch_optionals();
+			
 			return 1;
 		} else {
 			$this->error = $this->db->error().' sql='.$sql;


### PR DESCRIPTION
# Fix [*#24278 #24329*]

Fix a problem where I was losing my invisible extra fields data every time I was updating a line inside fichinter card

Now we fetch the extra fields before doing an array_merge to update the EF changed and not lose the invisible EF data