### PR TITLE
CORE mrp: Add option on the MRP module for set by default the remaining quantities to be consumed

### DIFF
--- a/htdocs/admin/mrp.php
+++ b/htdocs/admin/mrp.php
@@ -469,6 +469,15 @@ print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">'
 print "</td></tr>\n";
 print '</form>';
 
+// Enable auto set remaining quantities to be consumed
+print '<tr class="oddeven">';
+print '<td>'.$langs->trans("MrpEnableAutoSetRemainingQuantitiesToBeConsumed").'</td>';
+print '<td class="right">';
+print ajax_constantonoff("MRP_AUTO_SET_REMAINING_QUANTITIES_TO_BE_CONSUMED", array(), $conf->entity);
+print '</td>';
+print "<td>&nbsp;</td>\n";
+print '</tr>';
+
 print '</table>';
 print '<br>';
 

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -2177,3 +2177,4 @@ IfYouUseAThirdTaxYouMustSetYouUseTheMainTax=If you want to use a third tax, you 
 DEBUGBAR_USE_LOG_FILE=Use the <b>dolibarr.log</b> file to trap Logs
 UsingLogFileShowAllRecordOfSubrequestButIsSlower=Use the dolibarr.log file to trap Logs instead of live memory catching. It allows to catch all logs instead of only log of current process (so including the one of ajax subrequests pages) but will make your instance very very slow. Not recommended.
 ShowQuickAddLink=Show a button to quickly add an element in top right menu
+MrpEnableAutoSetRemainingQuantitiesToBeConsumed=Set by default the remaining quantities to be consumed when click on the button "Consume or Produce"

--- a/htdocs/langs/fr_FR/admin.lang
+++ b/htdocs/langs/fr_FR/admin.lang
@@ -2222,3 +2222,4 @@ IfYouUseASecondTaxYouMustSetYouUseTheMainTax=If you want to use a second tax, yo
 IfYouUseAThirdTaxYouMustSetYouUseTheMainTax=If you want to use a third tax, you must enable also the first sale tax
 PDF_USE_1A=Générer les PDF au format PDF/A-1b
 ShowQuickAddLink=Afficher un bouton pour ajouter rapidement un élément, dans le menu en haut à droite
+MrpEnableAutoSetRemainingQuantitiesToBeConsumed=Définit par défaut les quantités restantes à consommer lorsque l'on appuie sur le bouton "Consommer ou produire"

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -917,7 +917,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 						print '<tr>';
 						print '<td><span class="opacitymedium">'.$langs->trans("ToConsume").'</span></td>';
 						$preselected = (GETPOSTISSET('qty-'.$line->id.'-'.$i) ? GETPOST('qty-'.$line->id.'-'.$i) : max(0, $line->qty - $alreadyconsumed));
-						if ($action == 'consumeorproduce' && !GETPOSTISSET('qty-'.$line->id.'-'.$i)) {
+						if ($action == 'consumeorproduce' && empty($conf->global->MRP_AUTO_SET_REMAINING_QUANTITIES_TO_BE_CONSUMED) && !GETPOSTISSET('qty-'.$line->id.'-'.$i)) {
 							$preselected = 0;
 						}
 						print '<td class="right"><input type="text" class="width50 right" name="qty-'.$line->id.'-'.$i.'" value="'.$preselected.'"></td>';


### PR DESCRIPTION
Add option on the MRP module for set by default the remaining quantities to be consumed when you click on the button "Consume or Produce"

PR #24387
