### PR TITLE
CORE extrafields: Fix css error on wordbreak for view extrafields (case on type 'text')

### DIFF
--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -216,7 +216,7 @@ if ((!empty($conf->global->EASYA_ONLY_SHOW_PUBLIC_TICKET_EF) || !in_array('ticke
 
 			$html_id = !empty($object->id) ? $object->element.'_extras_'.$tmpkeyextra.'_'.$object->id : '';
 
-			print '<td id="'.$html_id.'" class="valuefield '.$object->element.'_extras_'.$tmpkeyextra.' wordbreak"'.(!empty($cols) ? ' colspan="'.$cols.'"' : '').'>';
+			print '<td id="'.$html_id.'" class="valuefield '.$object->element.'_extras_'.$tmpkeyextra.' wordbreakimp"'.(!empty($cols) ? ' colspan="'.$cols.'"' : '').'>';
 
 			// Convert date into timestamp format
 			if (in_array($extrafields->attributes[$object->table_element]['type'][$tmpkeyextra], array('date'))) {


### PR DESCRIPTION
Fix css error on wordbreak for view extrafields (case on type 'text')
PR #24390

Before:
![image](https://user-images.githubusercontent.com/28301879/228781481-f8802f9a-0624-45e8-a33b-9f962418d779.png)

After:
![image](https://user-images.githubusercontent.com/28301879/228781503-21c43b07-4c30-4abf-bab0-cda1dd1bc327.png)
