### PR TITLE
FIX edit field value of url

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -246,7 +246,7 @@ class Form
 				if (empty($notabletag)) {
 					$ret .= '<tr><td>';
 				}
-				if (preg_match('/^(string|safehtmlstring|email)/', $typeofdata)) {
+				if (preg_match('/^(string|safehtmlstring|email|url)/', $typeofdata)) {
 					$tmp = explode(':', $typeofdata);
 					$ret .= '<input type="text" id="'.$htmlname.'" name="'.$htmlname.'" value="'.($editvalue ? $editvalue : $value).'"'.(empty($tmp[1]) ? '' : ' size="'.$tmp[1].'"').' autofocus>';
 				} elseif (preg_match('/^(integer)/', $typeofdata)) {
@@ -320,6 +320,8 @@ class Form
 			} else {
 				if (preg_match('/^(email)/', $typeofdata)) {
 					$ret .= dol_print_email($value, 0, 0, 0, 0, 1);
+				} elseif (preg_match('/^url/', $typeofdata)) {
+					$ret .= dol_print_url($value, '_blank', 32, 1);
 				} elseif (preg_match('/^(amount|numeric)/', $typeofdata)) {
 					$ret .= ($value != '' ? price($value, '', $langs, 0, -1, -1, $conf->currency) : '');
 				} elseif (preg_match('/^(checkbox)/', $typeofdata)) {


### PR DESCRIPTION
FIX edit field value of url
- when you add an url field in an object class : 
'short_pdf_link' => array('type'=>'url', 'label'=>'ShortPDFlink, 'enabled'=>1, 'position'=>10, 'visible'=>4, 'alwayseditable'=>1)
- you have no input to edit this field

The url type was missing in the "fieldeditval" function.

**Before**
In view mode : 
![image](https://user-images.githubusercontent.com/45359511/235184044-f5f328c1-eed3-40c5-a55d-177a824d17f1.png)

In edit mode : 
![image](https://user-images.githubusercontent.com/45359511/235184176-d130c6e7-17c4-467e-9fb2-0b2926e57ee3.png)

**After**
In view mode : 
![image](https://user-images.githubusercontent.com/45359511/235184555-5ac35b48-11f9-4239-8f47-ff4d6f987dd4.png)

In edit mode : 
![image](https://user-images.githubusercontent.com/45359511/235184647-4ee41900-cfe9-445e-9cb2-2c209be1050d.png)
