### PR TITLE
Afficher le fullname avec lien contact sur les réponses clients

### DIFF
--- a/htdocs/contact/class/contact.class.php
+++ b/htdocs/contact/class/contact.class.php
@@ -1472,7 +1472,7 @@ class Contact extends CommonObject
 			$linkend = '</a>';
 		}
 
-		$result .= $linkstart;
+		$result .= (($option == 'nolink') ? '' : $linkstart);
 		if ($withpicto) {
 			if ($withpicto == -2) {
 				$result .= '<!-- picto photo user --><span class="nopadding userimg'.($moreparam ? ' '.$moreparam : '').'">'.Form::showphoto('contact', $this, 0, 0, 0, 'userphoto'.($withpicto == -3 ? 'small' : ''), 'mini', 0, 1).'</span>';
@@ -1483,7 +1483,7 @@ class Contact extends CommonObject
 		if ($withpicto != 2 && $withpicto != -2) {
 			$result .= ($maxlen ?dol_trunc($this->getFullName($langs), $maxlen) : $this->getFullName($langs));
 		}
-		$result .= $linkend;
+		$result .= (($option == 'nolink') ? '' : $linkend);
 
 		global $action;
 		$hookmanager->initHooks(array('contactdao'));

--- a/htdocs/core/lib/ticket.lib.php
+++ b/htdocs/core/lib/ticket.lib.php
@@ -317,6 +317,7 @@ function show_ticket_messaging($conf, $langs, $db, $filterobj, $objcon = '', $no
 		$sql .= " a.percent as percent, 'action' as type,";
 		$sql .= " a.fk_element, a.elementtype,";
 		$sql .= " a.fk_contact,";
+		$sql .= " a.email_from as msg_from,";
 		$sql .= " c.code as acode, c.libelle as alabel, c.picto as apicto,";
 		$sql .= " u.rowid as user_id, u.login as user_login, u.photo as user_photo, u.firstname as user_firstname, u.lastname as user_lastname";
 		if (is_object($filterobj) && get_class($filterobj) == 'Societe') {
@@ -516,6 +517,7 @@ function show_ticket_messaging($conf, $langs, $db, $filterobj, $objcon = '', $no
 						'userfirstname'=>$obj->user_firstname,
 						'userlastname'=>$obj->user_lastname,
 						'userphoto'=>$obj->user_photo,
+						'msg_from'=>$obj->msg_from,
 
 						'contact_id'=>$obj->fk_contact,
 						'socpeopleassigned' => $contactaction->socpeopleassigned,
@@ -579,6 +581,7 @@ function show_ticket_messaging($conf, $langs, $db, $filterobj, $objcon = '', $no
 		$userstatic = new User($db);
 		$contactstatic = new Contact($db);
 		$userGetNomUrlCache = array();
+		$contactGetNomUrlCache = array();
 
 		$out .= '<div class="filters-container" >';
 		$out .= '<form name="listactionsfilter" class="listactionsfilter" action="'.$_SERVER["PHP_SELF"].'" method="POST">';
@@ -744,6 +747,17 @@ function show_ticket_messaging($conf, $langs, $db, $filterobj, $objcon = '', $no
 					$userGetNomUrlCache[$histo[$key]['userid']] = $userstatic->getNomUrl(-1, '', 0, 0, 16, 0, 'firstelselast', '');
 				}
 				$out .= $userGetNomUrlCache[$histo[$key]['userid']];
+			}
+			else if (!empty($histo[$key]['msg_from']) && $actionstatic->code == 'TICKET_MSG') {
+				if (!isset($contactGetNomUrlCache[$histo[$key]['msg_from']])) {
+					if ($contactstatic->fetch(0,null,'',$histo[$key]['msg_from']) > 0) {
+						$contactGetNomUrlCache[$histo[$key]['msg_from']] = $contactstatic->getNomUrl(-1, '', 16);
+					}
+					else {
+						$contactGetNomUrlCache[$histo[$key]['msg_from']] = $histo[$key]['msg_from'];
+					}
+				}
+				$out .= $contactGetNomUrlCache[$histo[$key]['msg_from']];
 			}
 			$out .= '</span>';
 

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -303,6 +303,14 @@ class ActionsTicket
 							if ($res) {
 								print $userstat->getNomUrl(0);
 							}
+						} else if (isset($arraymsgs['fk_contact_author'])) {
+							$contactstat = new Contact($this->db);
+							$res = $contactstat->fetch(0, null, '', $arraymsgs['fk_contact_author']);
+							if ($res) {
+								print $contactstat->getNomUrl(0, 'nolink');
+							} else {
+								print $arraymsgs['fk_contact_author'];
+							}
 						} else {
 							print $langs->trans('Customer');
 						}

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1699,6 +1699,9 @@ class Ticket extends CommonObject
 		if ($this->private) {
 			$actioncomm->code = 'TICKET_MSG_PRIVATE';
 		}
+		if (empty($user->id) || $user->id == 0) {
+			$actioncomm->email_from = $_SESSION['email_customer'];
+		}
 		$actioncomm->socid = $this->socid;
 		$actioncomm->label = $this->subject;
 		$actioncomm->note_private = $this->message;
@@ -1751,7 +1754,7 @@ class Ticket extends CommonObject
 
 		// Cache already loaded
 
-		$sql = "SELECT id as rowid, fk_user_author, datec, label, note as message, code";
+		$sql = "SELECT id as rowid, fk_user_author, email_from, datec, label, note as message, code";
 		$sql .= " FROM ".MAIN_DB_PREFIX."actioncomm";
 		$sql .= " WHERE fk_element = ".(int) $this->id;
 		$sql .= " AND elementtype = 'ticket'";
@@ -1766,6 +1769,9 @@ class Ticket extends CommonObject
 				$obj = $this->db->fetch_object($resql);
 				$this->cache_msgs_ticket[$i]['id'] = $obj->rowid;
 				$this->cache_msgs_ticket[$i]['fk_user_author'] = $obj->fk_user_author;
+				if ($obj->code == 'TICKET_MSG' && empty($obj->fk_user_author)) {
+					$this->cache_msgs_ticket[$i]['fk_contact_author'] = $obj->email_from;
+				}
 				$this->cache_msgs_ticket[$i]['datec'] = $this->db->jdate($obj->datec);
 				$this->cache_msgs_ticket[$i]['subject'] = $obj->label;
 				$this->cache_msgs_ticket[$i]['message'] = $obj->message;


### PR DESCRIPTION
# New [*#24646*]

Nous pouvons maintenant voir le nom complet avec le lien vers leurs cartes ou seulement leurs emails dans le cas ou l'utilisateur n'est pas trouvé dans le cas ou l'option
![option ticket](https://user-images.githubusercontent.com/122890855/235861213-4a90ee94-4cfc-4741-8b98-bc319eee9724.png)

Dans ce screenshot, TEST Jean et MANIQUANT sont des clients qui ont envoyé des messages via l'interface publique des tickets et c'est ce que l'on peut voir sur la page publique :
![Public interface message side](https://user-images.githubusercontent.com/122890855/235861676-142b08dc-0278-4048-af83-f5e1de313697.png)

Ici, nous avons le même cas que ci-dessus, mais vu du côté de la carte du ticket :
![ticket card interface](https://user-images.githubusercontent.com/122890855/235862131-23f419d3-20d8-4d47-9173-668e180189e6.png)

Pour les screenshot suivant, nous observons le cas ou un utilisateur n'est pas trouvé :
![User not found public side](https://user-images.githubusercontent.com/122890855/235862646-7781257b-603a-485b-a86e-697471d70c7b.png)
![User not found show email](https://user-images.githubusercontent.com/122890855/235862662-bb908173-4a35-4cf9-9c8d-99c2bd9dfafd.png)
