### PR TITLE
Fix "html" type extrafields

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2244,6 +2244,11 @@ class ExtraFields
 						$value_arr = GETPOST($keysuffix."options_".$key.$keyprefix);
 						$value_key = $value_arr;
 					}
+				} elseif (in_array($key_type, array('html'))) {
+					if (!GETPOSTISSET($keysuffix."options_".$key.$keyprefix)) {
+						continue; // Value was not provided, we should not set it.
+					}
+					$value_key = dol_htmlcleanlastbr(GETPOST($keysuffix."options_".$key.$keyprefix, 'restricthtml'));
 				} else {
 					if (!GETPOSTISSET($keysuffix."options_".$key.$keyprefix)) {
 						continue; // Value was not provided, we should not set it.


### PR DESCRIPTION
# Fix #[*#24821*]
When an extrafield is in type HTML and you pass by the function getOptionalsFromPost, we lose all HTML from the EF.

With this modification, we do a GETPOST with the check at 'htmlrestrict' and not empty ('alphanohtml' in this case) value