### PR TITLE
FIX SQL injection on update user rights

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -115,7 +115,7 @@ function testSqlAndScriptInject($val, $type)
 		$inj += preg_match('/user\s*\(/i', $val); // avoid to use function user() or mysql_user() that return current database login
 		$inj += preg_match('/information_schema/i', $val); // avoid to use request that read information_schema database
 		$inj += preg_match('/<svg/i', $val); // <svg can be allowed in POST
-		$inj += preg_match('/update.+set.+=/i', $val);
+		$inj += preg_match('/update[^&=\w].*set[^&=\w].*=/i', $val);	// the [^&] test is to avoir error when request is like action=update&...set...
 		$inj += preg_match('/union.+select/i', $val);
 	}
 	if ($type == 3) {

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -115,7 +115,7 @@ function testSqlAndScriptInject($val, $type)
 		$inj += preg_match('/user\s*\(/i', $val); // avoid to use function user() or mysql_user() that return current database login
 		$inj += preg_match('/information_schema/i', $val); // avoid to use request that read information_schema database
 		$inj += preg_match('/<svg/i', $val); // <svg can be allowed in POST
-		$inj += preg_match('/update[^&=\w].*set[^&=\w].*=/i', $val);	// the [^&] test is to avoir error when request is like action=update&...set...
+		$inj += preg_match('/update[^&=\w].*set.+=/i', $val);	// the [^&=\w] test is to avoid error when request is like action=update&...set... or &updatemodule=...set...
 		$inj += preg_match('/union.+select/i', $val);
 	}
 	if ($type == 3) {

--- a/test/phpunit/SecurityTest.php
+++ b/test/phpunit/SecurityTest.php
@@ -202,6 +202,11 @@ class SecurityTest extends PHPUnit\Framework\TestCase
 		$result=testSqlAndScriptInject($test, 0);
 		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject expected 0c');
 
+		$test='/user/perms.php?id=1&action=addrights&entity=1&rights=123&confirm=yes&token=123456789&updatedmodulename=lmscoursetracking';
+		$result=testSqlAndScriptInject($test, 1);
+		print "test=".$test." result=".$result."\n";
+		$this->assertEquals($expectedresult, $result, 'Error on testSqlAndScriptInject with a valid url');
+
 		// Should detect attack
 		$expectedresult=1;
 


### PR DESCRIPTION
FIX SQL injection on update user rights
DLB : #24991
- you can't modify user rights when the name of the module contains "set" such as "lmscoursetracking"
- you got an SQL injection : 
"Script injection protection in main.inc.php"

**To reproduce** : 
1) go to user rights page
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/319e80c1-4211-4e27-838a-3843ad07eeff)

2) Try with this url : /user/perms.php?id=1&action=addrights&entity=1&rights=16311919&confirm=yes&token=fe07a75faf0d0a8c154d116e3c97ef9b&updatedmodulename=lmscoursetracking&page_y=5041

3) You got SQL injection page even if it's a valid url without SQL requests.
