### PR TITLE
CORE expedition: Ajout de la fonction get_substitutionarray_other() dans le modele ODT des expédition

### DIFF
--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -457,6 +457,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 
 				// Replace tags of object + external modules
 				$tmparray = array_merge($tmparray, $this->get_substitutionarray_shipment($object, $outputlangs));
+				$tmparray = array_merge($tmparray, $this->get_substitutionarray_other($outputlangs));
 
 				complete_substitutions_array($tmparray, $outputlangs, $object);
 				// Call the ODTSubstitution hook


### PR DESCRIPTION
Ajout de la fonction get_substitutionarray_other() dans le modele ODT des expédition PR #25080