### PR TITLE
FIX bookmark url params (backport DLB v17)

### DIFF
--- a/htdocs/bookmarks/bookmarks.lib.php
+++ b/htdocs/bookmarks/bookmarks.lib.php
@@ -73,7 +73,7 @@ function printDropdownBookmarksList()
 	}
 	$url .= ($tmpurl ? '?'.$tmpurl : '');
 	if (!empty($url_param)) {
-		$url .= '&'.implode('&', $url_param);
+		$url .= (strpos($url, '?') > 0 ? '&' : '?').implode('&', $url_param);
 	}
 
 	$searchForm = '<!-- form with POST method by default, will be replaced with GET for external link by js -->'."\n";


### PR DESCRIPTION
FIX bookmark url params (backport DLB v17)
- url in bookmark not contain "?" before params

**To reproduce :**
- bookmark any thirdparty card or other cards
- bookmark any other page than list