### PR TITLE
Extend the IMPORT_LINKED_OBJECT_LINES option to invoices (#25257)

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -763,6 +763,9 @@ if (empty($reshook)) {
 			} elseif ($fromElement == 'propal') {
 				dol_include_once('/comm/'.$fromElement.'/class/'.$fromElement.'.class.php');
 				$lineClassName = 'PropaleLigne';
+			} elseif ($fromElement == 'facture') {
+				dol_include_once('/compta/'.$fromElement.'/class/'.$fromElement.'.class.php');
+				$lineClassName = 'FactureLigne';
 			}
 			$nextRang = count($object->lines) + 1;
 			$importCount = 0;
@@ -2863,7 +2866,7 @@ if ($action == 'create') {
 
 		$compatibleImportElementsList = false;
 		if ($user->rights->propal->creer && $object->statut == Propal::STATUS_DRAFT) {
-			$compatibleImportElementsList = array('commande', 'propal'); // import from linked elements
+			$compatibleImportElementsList = array('commande', 'propal', 'facture'); // import from linked elements
 		}
 		$somethingshown = $form->showLinkedObjectBlock($object, $linktoelem, $compatibleImportElementsList);
 

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1341,6 +1341,9 @@ if (empty($reshook)) {
 			} elseif ($fromElement == 'propal') {
 				dol_include_once('/comm/'.$fromElement.'/class/'.$fromElement.'.class.php');
 				$lineClassName = 'PropaleLigne';
+			} elseif ($fromElement == 'facture') {
+				dol_include_once('/compta/'.$fromElement.'/class/'.$fromElement.'.class.php');
+				$lineClassName = 'FactureLigne';
 			}
 			$nextRang = count($object->lines) + 1;
 			$importCount = 0;
@@ -2805,7 +2808,7 @@ if ($action == 'create' && $usercancreate) {
 			$compatibleImportElementsList = false;
 			if ($usercancreate
 				&& $object->statut == Commande::STATUS_DRAFT) {
-				$compatibleImportElementsList = array('commande', 'propal'); // import from linked elements
+				$compatibleImportElementsList = array('commande', 'propal', 'facture'); // import from linked elements
 			}
 			$somethingshown = $form->showLinkedObjectBlock($object, $linktoelem, $compatibleImportElementsList);
 

--- a/htdocs/compta/facture/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/compta/facture/tpl/linkedobjectblock.tpl.php
@@ -66,6 +66,9 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 			echo $langs->trans("CustomerInvoice");
 			break;
 	}
+	if (!empty($showImportButton) && !empty($conf->global->MAIN_ENABLE_IMPORT_LINKED_OBJECT_LINES)) {
+		print '<a class="objectlinked_importbtn" href="'.$objectlink->getNomUrl(0, '', 0, 1).'&amp;action=selectlines" data-element="'.$objectlink->element.'" data-id="'.$objectlink->id.'"  > <i class="fa fa-indent"></i> </a';
+	}
 	print '</td>';
 	print '<td class="linkedcol-name nowraponall">'.$objectlink->getNomUrl(1).'</td>';
 	print '<td class="linkedcol-ref left">'.$objectlink->ref_client.'</td>';


### PR DESCRIPTION
[#25257](https://github.com/Dolibarr/dolibarr/pull/25257)
When you use this option : MAIN_ENABLE_IMPORT_LINKED_OBJECT_LINES, you may import lines from orders or proposals but not from invoices !

I extend this option to import lines also from invoice to new proposal or order.