### PR TITLE
FIX extrafield on update card when visibility is list or read only

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2086,6 +2086,12 @@ class ExtraFields
 				if (isset($this->attributes[$object->table_element]['list'][$key])) {
 					$enabled = intval(dol_eval($this->attributes[$object->table_element]['list'][$key], 1));
 				}
+
+				$visibility = 1;
+				if (isset($this->attributes[$object->table_element]['list'][$key])) {		// 'list' is option for visibility
+					$visibility = intval(dol_eval($this->attributes[$object->table_element]['list'][$key], 1));
+				}
+
 				$perms = 1;
 				if (isset($this->attributes[$object->table_element]['perms'][$key])) {
 					$perms = dol_eval($this->attributes[$object->table_element]['perms'][$key], 1);
@@ -2099,6 +2105,11 @@ class ExtraFields
 						&& ! GETPOSTISSET('options_' . $key) // Update hidden checkboxes and multiselect only if they are provided
 					)
 				) {
+					continue;
+				}
+				$visibility_abs = abs($visibility);
+				// not modify if extra field is not in update form (0 : never, 2 or -2 : list only, 5 or - 5 : list and view only)
+				if (empty($visibility_abs) || $visibility_abs == 2 || $visibility_abs == 5) {
 					continue;
 				}
 				if (empty($perms)) {


### PR DESCRIPTION
FIX extrafield on update card when visibility is list or read only
- DLB : #25355
- when you update a card with a visibility is list only [=-2 or =2] or read only [=5 or -5], the value is updated and set an empty value

**To reproduce**
1) try with theses extra fields
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/c58718da-ec76-4c84-be64-d70f0f074980)

2) set values in databases

3) update you third-party card with any changes

Finally theses extra fields are reset with an empty value