### PR TITLE
FIX no link on supplier invoice card for standalone credit note

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2825,9 +2825,13 @@ if ($action == 'create') {
 			print ' ('.$langs->transnoentities("ReplaceInvoice", $facreplaced->getNomUrl(1)).')';
 		}
 		if ($object->type == FactureFournisseur::TYPE_CREDIT_NOTE) {
-			$facusing = new FactureFournisseur($db);
-			$facusing->fetch($object->fk_facture_source);
-			print ' ('.$langs->transnoentities("CorrectInvoice", $facusing->getNomUrl(1)).')';
+			if ($object->fk_facture_source > 0) {
+				$facusing = new FactureFournisseur($db);
+				$facusing->fetch($object->fk_facture_source);
+				print ' (' . $langs->transnoentities("CorrectInvoice", $facusing->getNomUrl(1)) . ')';
+			} else {
+				print ' <span class="opacitymediumbycolor paddingleft">'.$langs->transnoentities("NoInvoiceToCorrect").'</span>';
+			}
 		}
 
 		$facidavoir = $object->getListIdAvoirFromInvoice();

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2830,7 +2830,8 @@ if ($action == 'create') {
 				$facusing->fetch($object->fk_facture_source);
 				print ' (' . $langs->transnoentities("CorrectInvoice", $facusing->getNomUrl(1)) . ')';
 			} else {
-				print ' <span class="opacitymediumbycolor paddingleft">'.$langs->transnoentities("NoInvoiceToCorrect").'</span>';
+				$langs->load("errors");
+				print ' <span class="opacitymediumbycolor paddingleft">'.$langs->transnoentities("WarningCorrectedInvoiceNotFound").'</span>';
 			}
 		}
 

--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -313,4 +313,4 @@ WarningCreateSubAccounts=Warning, you can't create directly a sub account, you m
 WarningAvailableOnlyForHTTPSServers=Available only if using HTTPS secured connection.
 WarningModuleXDisabledSoYouMayMissEventHere=Module %s has not been enabled. So you may miss a lot of event here.
 WarningPaypalPaymentNotCompatibleWithStrict=The value 'Strict' makes the online payment features not working correctly. Use 'Lax' instead.
-
+WarningCorrectedInvoiceNotFound=Corrected invoice not found

--- a/htdocs/langs/fr_FR/errors.lang
+++ b/htdocs/langs/fr_FR/errors.lang
@@ -309,6 +309,7 @@ WarningCreateSubAccounts=Attention, vous ne pouvez pas créer directement un com
 WarningAvailableOnlyForHTTPSServers=Disponible uniquement si une connexion sécurisée HTTPS est utilisée
 WarningModuleXDisabledSoYouMayMissEventHere=Le module %s n’a pas été activé. Par conséquent, il se peut que vous manquiez beaucoup d’événements ici.
 WarningPaypalPaymentNotCompatibleWithStrict=La valeur 'Strict' fait que les fonctionnalités de paiement en ligne ne fonctionnent pas correctement. Utilisez plutôt 'Lax'.
+WarningCorrectedInvoiceNotFound=Pas de correction de facture
 
 # Validate
 RequireValidValue = Valeur non valide


### PR DESCRIPTION
FIX no link on supplier invoice card for standalone credit note

DLB : #25588

When INVOICE_CREDIT_NOTE_STANDALONE is enabled and you create a standalone invoice, you got a link with an invoice for correction.

**Before**
![image](https://github.com/Easya-Solutions/dolibarr/assets/45359511/ca944b0e-aeed-4e77-bb81-39ec7707d302)

**After**
![image](https://github.com/Easya-Solutions/dolibarr/assets/45359511/1482f560-4740-4140-a899-2fbcbec16742)
