### PR TITLE
FIX dir output path for ODT models on reception card

### DIFF
--- a/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
+++ b/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
@@ -233,7 +233,7 @@ class doc_generic_reception_odt extends ModelePdfReception
 
 		$outputlangs->loadLangs(array("main", "dict", "companies", "bills"));
 
-		if ($conf->reception->dir_output."/reception") {
+		if ($conf->reception->dir_output) {
 			// If $object is id instead of object
 			if (!is_object($object)) {
 				$id = $object;
@@ -247,7 +247,7 @@ class doc_generic_reception_odt extends ModelePdfReception
 
 			$object->fetch_thirdparty();
 
-			$dir = $conf->reception->dir_output."/reception";
+			$dir = !empty($conf->reception->multidir_output[$object->entity]) ? $conf->reception->multidir_output[$object->entity] : $conf->reception->dir_output;
 			$objectref = dol_sanitizeFileName($object->ref);
 			if (!preg_match('/specimen/i', $objectref)) {
 				$dir .= "/".$objectref;

--- a/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
+++ b/htdocs/core/modules/reception/doc/doc_generic_reception_odt.modules.php
@@ -420,7 +420,7 @@ class doc_generic_reception_odt extends ModelePdfReception
 						$linenumber = 0;
 						foreach ($object->lines as $line) {
 							$linenumber++;
-							$tmparray = $this->get_substitutionarray_reception_lines($line, $outputlangs);
+							$tmparray = $this->get_substitutionarray_lines($line, $outputlangs);
 							complete_substitutions_array($tmparray, $outputlangs, $object, $line, "completesubstitutionarray_lines");
 							// Call the ODTSubstitutionLine hook
 							$parameters = array('odfHandler'=>&$odfHandler, 'file'=>$file, 'object'=>$object, 'outputlangs'=>$outputlangs, 'substitutionarray'=>&$tmparray, 'line'=>$line);

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -366,7 +366,7 @@ class Reception extends CommonObject
 			return -1;
 		}
 
-		$sql = "SELECT e.rowid, e.ref, e.fk_soc as socid, e.date_creation, e.ref_supplier, e.ref_ext, e.fk_user_author, e.fk_statut";
+		$sql = "SELECT e.rowid, e.entity, e.ref, e.fk_soc as socid, e.date_creation, e.ref_supplier, e.ref_ext, e.fk_user_author, e.fk_statut";
 		$sql .= ", e.weight, e.weight_units, e.size, e.size_units, e.width, e.height";
 		$sql .= ", e.date_reception as date_reception, e.model_pdf,  e.date_delivery";
 		$sql .= ", e.fk_shipping_method, e.tracking_number";
@@ -395,6 +395,7 @@ class Reception extends CommonObject
 				$obj = $this->db->fetch_object($result);
 
 				$this->id                   = $obj->rowid;
+				$this->entity               = $obj->entity;
 				$this->ref                  = $obj->ref;
 				$this->socid                = $obj->socid;
 				$this->ref_supplier = $obj->ref_supplier;


### PR DESCRIPTION
FIX dir output path for ODT models on reception card

DLB : #25659

**Before**
- we got an error 500 due to call of wrong function "get_substitutionarray_reception_lines"

**After**
- when I replaced "get_substitutionarray_reception_lines" with "get_substitutionarray_lines" (see fix on PR  #25601), the document was generated on a wrong sub-directory "reception" and was not visible on reception card
- with theses fixes, ODT is now generated without errors and on reception card we have the link to download the ODT file