### PR TITLE
FIX : message order in ticket public view

### DIFF
--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -293,7 +293,7 @@ class ActionsTicket
 					//print '<tr>';
 					print '<tr class="oddeven">';
 					print '<td><strong>';
-					print img_picto('', 'object_action', 'class="paddingright"').dol_print_date($arraymsgs['datec'], 'dayhour');
+					print img_picto('', 'object_action', 'class="paddingright"').dol_print_date($arraymsgs['datep'], 'dayhour');
 					print '<strong></td>';
 					if ($show_user) {
 						print '<td>';

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1754,11 +1754,11 @@ class Ticket extends CommonObject
 
 		// Cache already loaded
 
-		$sql = "SELECT id as rowid, fk_user_author, email_from, datec, label, note as message, code";
+		$sql = "SELECT id as rowid, fk_user_author, email_from, datec, datep, label, note as message, code";
 		$sql .= " FROM ".MAIN_DB_PREFIX."actioncomm";
 		$sql .= " WHERE fk_element = ".(int) $this->id;
 		$sql .= " AND elementtype = 'ticket'";
-		$sql .= " ORDER BY datec DESC";
+		$sql .= " ORDER BY datep DESC";
 
 		dol_syslog(get_class($this)."::load_cache_actions_ticket sql=".$sql, LOG_DEBUG);
 		$resql = $this->db->query($sql);
@@ -1773,6 +1773,7 @@ class Ticket extends CommonObject
 					$this->cache_msgs_ticket[$i]['fk_contact_author'] = $obj->email_from;
 				}
 				$this->cache_msgs_ticket[$i]['datec'] = $this->db->jdate($obj->datec);
+				$this->cache_msgs_ticket[$i]['datep'] = $this->db->jdate($obj->datep);
 				$this->cache_msgs_ticket[$i]['subject'] = $obj->label;
 				$this->cache_msgs_ticket[$i]['message'] = $obj->message;
 				$this->cache_msgs_ticket[$i]['private'] = ($obj->code == 'TICKET_MSG_PRIVATE' ? 1 : 0);


### PR DESCRIPTION
#25802

# Fix : message order in ticket public view is not coherent with tickets events tab

Tickets messages are ordered by creation date (datec) on public view and by user-enterd date (datep) on ticket events tab.

We want to have them ordered by datep.

The bug rises as following : 

1. We have a ticket with written messages (ex. email discussion)

![image](https://github.com/Dolibarr/dolibarr/assets/89838020/507be601-a804-4e70-8e3a-3b99c2212c74)

3. The user who manages the message enters an action that took place before the last email (ex. a phone call 3 days ago). The user enters the right date.

5.  On the events view, the order of events by datep is OK, but events are ordered by datec on public view. The date shown on public view is also datec.

![image](https://github.com/Dolibarr/dolibarr/assets/89838020/7c4268fe-fafd-4267-925f-6aeb69bbc0f1)

![image](https://github.com/Dolibarr/dolibarr/assets/89838020/a011eb2c-a1a3-4bb3-bf19-a03e45cd3350)


This PR :
- orders tickets messages by datep
- make `datep` the date shown on public view for messages

![image](https://github.com/Dolibarr/dolibarr/assets/89838020/f76f6fb9-2d47-4b73-bcfd-20eb2dd3d644)

