### PR TITLE
FIX remove special product lines on discount create (PR #21068)

### DIFF
--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -424,7 +424,7 @@ class Paiement extends CommonObject
 										// Loop on each vat rate
 										$i = 0;
 										foreach ($invoice->lines as $line) {
-											if ($line->total_ht != 0) {    // no need to create discount if amount is null
+											if ($line->product_type != 9 && $line->total_ht != 0) {    // no need to create discount if special product or amount is null
 												$amount_ht[$line->tva_tx] += $line->total_ht;
 												$amount_tva[$line->tva_tx] += $line->total_tva;
 												$amount_ttc[$line->tva_tx] += $line->total_ttc;


### PR DESCRIPTION
FIX remove special product lines on discount create
- avoid from creating a discount (got from invoice deposit payment) when we have lines with a special product
- otherwise amounts were added twice (one time for special product line and other time in components lines)
