### PR TITLE
FIX group by in count elements on invoice list

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -942,7 +942,6 @@ $nbtotalofrecords = '';
 if (!getDolGlobalInt('MAIN_DISABLE_FULL_SCANLIST')) {
 	/* The fast and low memory method to get and count full list converts the sql into a sql count */
 	$sqlforcount = preg_replace('/^'.preg_quote($sqlfields, '/').'/', 'SELECT COUNT(*) as nbtotalofrecords', $sql);
-	$sqlforcount = preg_replace('/GROUP BY .*$/', '', $sqlforcount);
 	$resql = $db->query($sqlforcount);
 	if ($resql) {
 		$objforcount = $db->fetch_object($resql);

--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -379,7 +379,6 @@ $nbtotalofrecords = '';
 if (!getDolGlobalInt('MAIN_DISABLE_FULL_SCANLIST')) {
 	/* The fast and low memory method to get and count full list converts the sql into a sql count */
 	$sqlforcount = preg_replace('/^'.preg_quote($sqlfields, '/').'/', 'SELECT COUNT(*) as nbtotalofrecords', $sql);
-	$sqlforcount = preg_replace('/GROUP BY .*$/', '', $sqlforcount);
 	$resql = $db->query($sqlforcount);
 	if ($resql) {
 		$objforcount = $db->fetch_object($resql);


### PR DESCRIPTION
FIX group by in count elements on invoice list
- DLB : #25965
When you have a sub-request with a "GROUP BY", the SQL request used to count elements remove all "GROUP BY".
So the sub-request is wrong (GROUP BY is missing) and the count request is also wrong.

**Example of subrequest from "printFieldListFrom" hook :**
LEFT JOIN (
	SELECT ee.fk_target as id_invoice, GROUP_CONCAT(DISTINCT link_src.rowid SEPARATOR ',') as link_propal
	FROM llx_element_element as ee 
	LEFT JOIN llx_propal as link_src ON link_src.rowid = ee.fk_source ABD ee.sourcetype='propal'
	WHERE ee.targettype = 'facture'
	GROUP BY ee.fk_target
) as link_fac ON link_fac.id_invoice = f.rowid

**Module builder**
And fix on object list of module builder