### PR TITLE
NEW key to detect a new line for shipping of serial numbers

### DIFF
--- a/htdocs/admin/expedition.php
+++ b/htdocs/admin/expedition.php
@@ -54,6 +54,23 @@ if (empty($conf->global->EXPEDITION_ADDON_NUMBER)) {
 	$conf->global->EXPEDITION_ADDON_NUMBER = 'mod_expedition_safor';
 }
 
+// Set this to 1 to use the factory to manage constants. Warning, the generated module will be compatible with version v15+ only
+$useFormSetup = 1;
+
+if (!class_exists('FormSetup')) {
+	require_once DOL_DOCUMENT_ROOT . '/core/class/html.formsetup.class.php';
+}
+
+$formSetup = new FormSetup($db);
+
+// Enable access for the membership record
+$batchNewLineAsciiCodeList = array(
+	-1 => $langs->trans('AsciiKeyNone'),
+	13 => $langs->trans('AsciiKeyEnter'),
+	59 => $langs->trans('AsciiKeySemiColon'),
+);
+$item = $formSetup->newItem('SHIPPING_BATCH_NEW_LINE_ASCII_CODE')->setAsSelect($batchNewLineAsciiCodeList);
+
 
 /*
  * Actions
@@ -171,6 +188,23 @@ print '<br>';
 $head = expedition_admin_prepare_head();
 
 print dol_get_fiche_head($head, 'shipment', $langs->trans("Sendings"), -1, 'shipment');
+
+// Setup page goes here
+echo '<span class="opacitymedium">' . $langs->trans("SendingsSetup") . '</span><br><br>';
+
+
+if ($action == 'edit') {
+	print $formSetup->generateOutput(true);
+	print '<br>';
+} elseif (!empty($formSetup->items)) {
+	print $formSetup->generateOutput();
+	print '<div class="tabsAction">';
+	print '<a class="butAction" href="' . $_SERVER["PHP_SELF"] . '?action=edit&token=' . newToken() . '">' . $langs->trans("Modify") . '</a>';
+	print '</div>';
+} else {
+	print '<br>' . $langs->trans("NothingToSetup");
+}
+
 
 // Shipment numbering model
 

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1153,8 +1153,13 @@ if ($action == 'create') {
 				$warehouseObj->get_children_warehouses($warehouse_id, $warehousePicking);
 			}
 
+			$splitAsciiCode = getDolGlobalInt('SHIPPING_BATCH_NEW_LINE_ASCII_CODE');
+			$serialInputFirst = true;
+
 			$indiceAsked = 0;
 			while ($indiceAsked < $numAsked) {
+				$jsLine = '';
+
 				$product = new Product($db);
 
 				$line = $object->lines[$indiceAsked];
@@ -1525,7 +1530,70 @@ if ($action == 'create') {
 							}
 						} else {
 							print '<!-- Case warehouse not already known and product need lot -->';
-							print '<td></td><td></td></tr>'; // end line and start a new one for lot/serial
+							print '<td></td>';
+							// only for serial number : batch status = 2 (not for product lot : batch status = 1)
+							$canSearchSerial = false;
+							if ($product->status_batch == 2 && $splitAsciiCode > 0) {
+								$canSearchSerial = true;
+							}
+							$serialInput = "serial_searchl".$indiceAsked;
+							print '<td>';
+							if ($canSearchSerial === true) {
+								print '<input type="text" id="' . $serialInput . '" name="' . $serialInput . '" value="">';
+							}
+							print '</td>';
+							print '</tr>'; // end line and start a new one for lot/serial
+
+							// serial search script
+							if ($canSearchSerial === true) {
+								$serialInput = dol_escape_js($serialInput);
+								if ($serialInputFirst === true) {
+									$jsLine .= 'jQuery("#' . $serialInput . '").focus();';
+									$serialInputFirst = false;
+								}
+								$jsLine .= 'var lineIndex = "' . dol_escape_js($indiceAsked) . '";';
+								// remove all quantities for this product only if form not already submit
+								if (!GETPOSTISSET('idl'.$indiceAsked)) {
+									$jsLine .= 'jQuery("input[name^=\"qtyl"+lineIndex+"\"]").val(0);';
+								}
+								$jsLine .= 'jQuery("#' . $serialInput . '").keypress(function(event){';
+								$jsLine .= '	var splitAsciiCode = "' . dol_escape_js($splitAsciiCode) . '";';
+								$jsLine .= '	if (event.which == splitAsciiCode) {';
+								$jsLine .= '		var serialToSearch = this.value;'; // search qty input for this serial number
+								$jsLine .= '		var serialInput = "batchl"+lineIndex+"_"+serialToSearch;';
+								$jsLine .= '		if (jQuery("#"+serialInput).length > 0) {';
+								$jsLine .= '			var serialInputName = jQuery("#"+serialInput).prop("name");';
+								$jsLine .= '			var inputSuffix = serialInputName.substr(6);'; // remove "batchl" in serial input name to find suffix
+								$jsLine .= '			jQuery("#qtyl"+inputSuffix).val(1);'; // set qty to 1 for serial number
+								$jsLine .= '			jQuery("#' . $serialInput . '").val("");'; // reset value to search
+								$jsLine .= '			var qtyDispatched = 0;';
+								$jsLine .= '			jQuery("input[name^=\"qtyl"+lineIndex+"\"]").each(function(idInput, qtyInputElem) {';
+								$jsLine .= '				qtyDispatched += parseFloat(jQuery(qtyInputElem).val());';
+								$jsLine .= '			});';
+								$jsLine .= '			var qtyAsked = parseFloat(jQuery("#qtyasked"+lineIndex).val());';
+								$jsLine .= '			var qtyRemain = qtyAsked - qtyDispatched;';
+								$jsLine .= '			console.log("qtyRemain=", qtyRemain);';
+								$jsLine .= '			if (qtyRemain <= 0) {'; // all serial numbers are set for this product : so change to next serial input
+								$jsLine .= '				var serialInputNext = jQuery(this).closest("tr").nextAll(":has(input[name^=\"serial_searchl\"]):first").find("input[name^=\"serial_searchl\"]");'; // next input for serial number
+								$jsLine .= '				if (serialInputNext.length > 0) {'; // found a next serial input
+								$jsLine .= '					serialInputNext.focus();';
+								$jsLine .= '				} else {'; // no next serial input : so go to create button
+								$jsLine .= '					jQuery("input[name=\"add\"]").focus();';
+								$jsLine .= '				}';
+								$jsLine .= '			}';
+								$jsLine .= '		}';
+								$jsLine .= '		return false;'; // stop propagation and avoid to submit form or to have separator char
+								$jsLine .= '	}';
+								$jsLine .= '});';
+
+								// output js
+								$js = '<script type="text/javascript">';
+								$js .= 'jQuery(document).ready(function(){';
+								$js .= $jsLine;
+								$js .= '});';
+								$js .= '</script>';
+								print $js;
+							}
 
 							$subj = 0;
 							print '<input name="idl'.$indiceAsked.'" type="hidden" value="'.$line->id.'">';
@@ -1591,7 +1659,7 @@ if ($action == 'create') {
 										print $tmpwarehouseObject->getNomUrl(0).' / ';
 
 										print '<!-- Show details of lot -->';
-										print '<input name="batchl'.$indiceAsked.'_'.$subj.'" type="hidden" value="'.$dbatch->id.'">';
+										print '<input name="batchl'.$indiceAsked.'_'.$subj.'" type="hidden" id="batchl'.$indiceAsked.'_'.$dbatch->batch.'" value="'.$dbatch->id.'">';
 
 										//print '|'.$line->fk_product.'|'.$dbatch->batch.'|<br>';
 										print $langs->trans("Batch").': ';

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -2406,3 +2406,7 @@ OptionXIsCorrectlyEnabledInModuleY=Option "<b>%s</b>" is enabled into module <b>
 AtBottomOfPage=At bottom of page
 FailedAuth=failed authentications
 MaxNumberOfFailedAuth=Max number of failed authentication in 24h to deny login.
+AsciiKeyNone=None
+AsciiKeyEnter=Key enter
+AsciiKeySemiColon=Key semi-colon
+SHIPPING_BATCH_NEW_LINE_ASCII_CODE=Key to detect a new line for the shipping of serial numbers


### PR DESCRIPTION
NEW key to detect a new line for shipping of serial numbers (barcode reader)
DLB : #25989
- add admin setup in shipping module

1. can configure a key (ASCII code) to detect a new line for shipping of serial numbers
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/1b700213-fecb-46ff-9496-d9400a1cee49)

- add javascript on each line of batch product if a key is set in setup of shipping module

1. set qty to 0 on each qty where the product has an unique serial number (not a product lot)
2. get focus on first serial input using to search a serial number
3. search qty for this serial number and set to 1
4. go on next serial input if found or go on create button

![image](https://github.com/Dolibarr/dolibarr/assets/45359511/90240e4f-e53a-401b-9f2b-3adb8697c19a)