### PR TITLE
FIX regression on rounding stocks fields on product list

### DIFF
--- a/htdocs/product/list.php
+++ b/htdocs/product/list.php
@@ -1804,7 +1804,7 @@ if ($resql) {
 				if ($obj->seuil_stock_alerte != '' && $product_static->stock_reel < (float) $obj->seuil_stock_alerte) {
 					print img_warning($langs->trans("StockLowerThanLimit", $obj->seuil_stock_alerte)).' ';
 				}
-				print price(price2num($product_static->stock_reel, 'MS'));
+				print price(price2num($product_static->stock_reel, 'MS'), 0, $langs, 1, 0);
 			}
 			print '</td>';
 			if (!$i) {
@@ -1818,7 +1818,7 @@ if ($resql) {
 				if ($obj->seuil_stock_alerte != '' && $product_static->stock_theorique < (float) $obj->seuil_stock_alerte) {
 					print img_warning($langs->trans("StockLowerThanLimit", $obj->seuil_stock_alerte)).' ';
 				}
-				print price(price2num($product_static->stock_theorique, 'MS'));
+				print price(price2num($product_static->stock_theorique, 'MS'), 0, $langs, 1, 0);
 			}
 			print '</td>';
 			if (!$i) {


### PR DESCRIPTION
FIX regression on rounding stocks fields on product list
- DLB : #26101
- values on real and virtual stocks were rounded with 2 decimals even if there were 0 after comma

**BEFORE**
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/a201e886-9a31-4d23-9823-5bcf9470eba6)

**AFTER**
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/3327d1a1-e7c6-4283-a077-43424de06039)
