### PR TITLE
2022.5.3 rc fix fec2 supplier invoice

### DIFF
--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -1643,21 +1643,13 @@ class AccountancyExport
 							$objectDirPath.= '/'.rtrim(get_exdir($invoice->id, 2, 0, 0, $invoice, 'invoice_supplier'),'/');
 						}
 						$arrayofinclusion = array();
-						$arrayofinclusion[] = '^'.preg_quote($objectFileName, '/').'.*\.pdf$';
+						// If it is a supplier invoice, we want to use last uploaded file
+						$arrayofinclusion[] = '^'.preg_quote($objectFileName, '/').(($line->doc_type == 'supplier_invoice') ? '.+' : '').'\.pdf$';
 						$fileFoundList = dol_dir_list($objectDirPath.'/'.$objectFileName, 'files', 0, implode('|', $arrayofinclusion), '(\.meta|_preview.*\.png)$', 'date', SORT_DESC, 0, true);
 						if (!empty($fileFoundList)) {
 							$attachmentFileNameTrunc = $line->doc_ref;
 							foreach ($fileFoundList as $fileFound) {
 								if (strstr($fileFound['name'], $objectFileName)) {
-
-									// skip native invoice pdfs (canelle) 
-									if ($line->doc_type == 'supplier_invoice'){
-										if ($fileFound['name'] === $objectFileName.'.pdf') continue;
-									}
-									elseif ($fileFound['name'] !== $objectFileName.'.pdf') {
-										continue;
-									}
-
 									$fileFoundPath = $objectDirPath.'/'.$objectFileName.'/'.$fileFound['name'];
 									if (file_exists($fileFoundPath)) {
 										$archiveFileList[$attachmentFileKey] = array(

--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -1640,14 +1640,24 @@ class AccountancyExport
 							$objectDirPath = !empty($conf->expensereport->multidir_output[$conf->entity]) ? $conf->expensereport->multidir_output[$conf->entity] : $conf->factureexpensereport->dir_output;
 						} elseif ($line->doc_type == 'supplier_invoice') {
 							$objectDirPath = !empty($conf->fournisseur->facture->multidir_output[$conf->entity]) ? $conf->fournisseur->facture->multidir_output[$conf->entity] : $conf->fournisseur->facture->dir_output;
+							$objectDirPath.= '/'.rtrim(get_exdir($invoice->id, 2, 0, 0, $invoice, 'invoice_supplier'),'/');
 						}
 						$arrayofinclusion = array();
-						$arrayofinclusion[] = '^'.preg_quote($objectFileName, '/').'\.pdf$';
+						$arrayofinclusion[] = '^'.preg_quote($objectFileName, '/').'.*\.pdf$';
 						$fileFoundList = dol_dir_list($objectDirPath.'/'.$objectFileName, 'files', 0, implode('|', $arrayofinclusion), '(\.meta|_preview.*\.png)$', 'date', SORT_DESC, 0, true);
 						if (!empty($fileFoundList)) {
 							$attachmentFileNameTrunc = $line->doc_ref;
 							foreach ($fileFoundList as $fileFound) {
 								if (strstr($fileFound['name'], $objectFileName)) {
+
+									// skip native invoice pdfs (canelle) 
+									if ($line->doc_type == 'supplier_invoice'){
+										if ($fileFound['name'] === $objectFileName.'.pdf') continue;
+									}
+									elseif ($fileFound['name'] !== $objectFileName.'.pdf') {
+										continue;
+									}
+
 									$fileFoundPath = $objectDirPath.'/'.$objectFileName.'/'.$fileFound['name'];
 									if (file_exists($fileFoundPath)) {
 										$archiveFileList[$attachmentFileKey] = array(


### PR DESCRIPTION
# FIX FEC2 : the supplier invoice files were not joined.

Problem is, there is no native PDF for supplier invoice. canelle is used by default but user has no choice.

This PR:
- adds the last PDF joined to the supplier invoice and renames it <doc_ref>.pdf
- does NOT add any PDF named <doc_ref>.pdf for supplier invoice since it is native DLB PDF (canelle)
- keeps the function for objects other than supplier invoices (joins <doc_ref>.pdf)