### PR TITLE
PHP 8.2 - Fix Accountancy 2 Warnings

### DIFF
--- a/htdocs/accountancy/admin/account.php
+++ b/htdocs/accountancy/admin/account.php
@@ -90,7 +90,7 @@ $arrayfields = array(
 	'aa.pcg_type'=>array('label'=>"Pcgtype", 'checked'=>1, 'help'=>'PcgtypeDesc'),
 	'categories'=>array('label'=>"AccountingCategories", 'checked'=>-1, 'help'=>'AccountingCategoriesDesc'),
 	'aa.reconcilable'=>array('label'=>"Reconcilable", 'checked'=>1),
-	'aa.import_key'=>array('label'=>"ImportId", 'checked'=>-1),
+	'aa.import_key'=>array('label'=>"ImportId", 'checked'=>-1, 'help'=>''),
 	'aa.active'=>array('label'=>"Activated", 'checked'=>1)
 );
 
@@ -413,7 +413,7 @@ if ($resql) {
 	print '<br>';
 
 	$varpage = empty($contextpage) ? $_SERVER["PHP_SELF"] : $contextpage;
-	$selectedfields = ($mode != 'kanban' ? $form->multiSelectArrayWithCheckbox('selectedfields', $arrayfields, $varpage, getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN', '')) : ''); // This also change content of $arrayfields
+	$selectedfields = ((!empty($mode) && $mode != 'kanban') ? $form->multiSelectArrayWithCheckbox('selectedfields', $arrayfields, $varpage, getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN', '')) : ''); // This also change content of $arrayfields
 	$selectedfields .= (count($arrayofmassactions) ? $form->showCheckAddButtons('checkforselect', 1) : '');
 
 	$moreforfilter = '';


### PR DESCRIPTION
With the help of Thomas NEGRE, 
I've fixed two Php Warnings on the page accountancy/admin/account.php

On line 416 undefined variable $mode
Then on line 504 undefined array key 'help' for import_key 

