### PR TITLE
CoreChange - PHP8.2 Warning for CSV Generator / Contracts and Extrafields

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -993,7 +993,7 @@ if (empty($reshook)) {
 	include DOL_DOCUMENT_ROOT.'/core/actions_printing.inc.php';
 
 	// Actions to build doc
-	if(empty($conf->contrat->multidir_output[$object->entity])) $conf->contrat->multidir_output[$object->entity] = array ();
+	if(empty($conf->contrat->multidir_output[$object->entity])) $conf->contrat->multidir_output[$object->entity] = '';
 	$upload_dir = $conf->contrat->multidir_output[$object->entity];
 	include DOL_DOCUMENT_ROOT.'/core/actions_builddoc.inc.php';
 

--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -993,6 +993,7 @@ if (empty($reshook)) {
 	include DOL_DOCUMENT_ROOT.'/core/actions_printing.inc.php';
 
 	// Actions to build doc
+	if(empty($conf->contrat->multidir_output[$object->entity])) $conf->contrat->multidir_output[$object->entity] = array ();
 	$upload_dir = $conf->contrat->multidir_output[$object->entity];
 	include DOL_DOCUMENT_ROOT.'/core/actions_builddoc.inc.php';
 
@@ -1093,6 +1094,8 @@ if ($action == 'create') {
 		$soc->fetch($socid);
 	}
 
+	// Initialize variable for PHP 8.2 compatibility 
+	$objectsrc = null;
 	if (GETPOST('origin') && GETPOST('originid', 'int')) {
 		// Parse element/subelement (ex: project_task)
 		$regs = array();

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -614,10 +614,11 @@ class ExtraFields
 				}
 			}
 
+			$result = null;
 			if ($type != 'separate') { // No table update when separate type
 				$result = $this->db->DDLUpdateField($this->db->prefix().$table, $attrname, $field_desc);
 			}
-			if ((isset($result) && $result > 0) || $type == 'separate') {
+			if ($result > 0 || $type == 'separate') {
 				if ($label) {
 					$result = $this->update_label($attrname, $label, $type, $length, $elementtype, $unique, $required, $pos, $param, $alwayseditable, $perms, $list, $help, $default, $computed, $entity, $langfile, $enabled, $totalizable, $printable, $moreparams);
 				}

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -617,7 +617,7 @@ class ExtraFields
 			if ($type != 'separate') { // No table update when separate type
 				$result = $this->db->DDLUpdateField($this->db->prefix().$table, $attrname, $field_desc);
 			}
-			if (isset($result) && $result > 0 || $type == 'separate') {
+			if ((isset($result) && $result > 0) || $type == 'separate') {
 				if ($label) {
 					$result = $this->update_label($attrname, $label, $type, $length, $elementtype, $unique, $required, $pos, $param, $alwayseditable, $perms, $list, $help, $default, $computed, $entity, $langfile, $enabled, $totalizable, $printable, $moreparams);
 				}

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -617,7 +617,7 @@ class ExtraFields
 			if ($type != 'separate') { // No table update when separate type
 				$result = $this->db->DDLUpdateField($this->db->prefix().$table, $attrname, $field_desc);
 			}
-			if ($result > 0 || $type == 'separate') {
+			if (isset($result) && $result > 0 || $type == 'separate') {
 				if ($label) {
 					$result = $this->update_label($attrname, $label, $type, $length, $elementtype, $unique, $required, $pos, $param, $alwayseditable, $perms, $list, $help, $default, $computed, $entity, $langfile, $enabled, $totalizable, $printable, $moreparams);
 				}

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -614,7 +614,7 @@ class ExtraFields
 				}
 			}
 
-			$result = null;
+			$result = 0;
 			if ($type != 'separate') { // No table update when separate type
 				$result = $this->db->DDLUpdateField($this->db->prefix().$table, $attrname, $field_desc);
 			}

--- a/htdocs/core/modules/export/exportcsv.class.php
+++ b/htdocs/core/modules/export/exportcsv.class.php
@@ -185,6 +185,7 @@ class ExportCsv extends ModeleExports
 		// phpcs:enable
 		global $conf;
 
+		if (empty ($conf->global->EXPORT_CSV_FORCE_CHARSET)) $conf->global->EXPORT_CSV_FORCE_CHARSET = '';
 		$outputlangs->charset_output = $conf->global->EXPORT_CSV_FORCE_CHARSET;
 
 		$selectlabel = array();
@@ -223,6 +224,7 @@ class ExportCsv extends ModeleExports
 		// phpcs:enable
 		global $conf;
 
+		if (empty ($conf->global->EXPORT_CSV_FORCE_CHARSET)) $conf->global->EXPORT_CSV_FORCE_CHARSET = '';
 		$outputlangs->charset_output = $conf->global->EXPORT_CSV_FORCE_CHARSET;
 
 		$this->col = 0;

--- a/htdocs/core/modules/export/exportcsv.class.php
+++ b/htdocs/core/modules/export/exportcsv.class.php
@@ -185,8 +185,7 @@ class ExportCsv extends ModeleExports
 		// phpcs:enable
 		global $conf;
 
-		if (empty ($conf->global->EXPORT_CSV_FORCE_CHARSET)) $conf->global->EXPORT_CSV_FORCE_CHARSET = '';
-		$outputlangs->charset_output = $conf->global->EXPORT_CSV_FORCE_CHARSET;
+		$outputlangs->charset_output = getDolGlobalString('EXPORT_CSV_FORCE_CHARSET');
 
 		$selectlabel = array();
 
@@ -224,8 +223,7 @@ class ExportCsv extends ModeleExports
 		// phpcs:enable
 		global $conf;
 
-		if (empty ($conf->global->EXPORT_CSV_FORCE_CHARSET)) $conf->global->EXPORT_CSV_FORCE_CHARSET = '';
-		$outputlangs->charset_output = $conf->global->EXPORT_CSV_FORCE_CHARSET;
+		$outputlangs->charset_output = getDolGlobalString('EXPORT_CSV_FORCE_CHARSET');
 
 		$this->col = 0;
 


### PR DESCRIPTION
With PHP8.2, using the file core/modules/export/exportcsv.class.php a warning can appear  : 
About that EXPORT_CSV_FORCE_CHARSET isn't initialized on function write_record and write_title

This Pull Request correct this Warning.
This should be reported to Dolibarr/Dolibarr