### PR TITLE
Fix running SQL files with multilines requests

### DIFF
--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -237,6 +237,7 @@ function run_sql($sqlfile, $silent = 1, $entity = '', $usesavepoint = 1, $handle
 				if (empty($nocommentremoval)) {
 					$buf = preg_replace('/([,;ERLT\)])\s*--.*$/i', '\1', $buf); //remove comment from a line that not start with -- before add it to the buffer
 				}
+				if ($buffer) $buffer .= ' ';
 				$buffer .= trim($buf);
 			}
 


### PR DESCRIPTION
Backport. Already in V17.

Quand on a un fichier SQL avec plusieurs lignes (en l'occurence une CREATE VIEW), la fonction fait un trim() sur chaque ligne et ne remplace pas les espaces. La syntaxe de la requête SQL devient fausse, car

```
CREATE VIEW view_coucou AS
SELECT * FROM coucou
```
devient
```
CREATE VIEW view_coucou ASSELECT * FROM coucou
```