### PR TITLE
CORE movement stock: Fix compare on float when test on stock dont allow negative transfert

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5630,12 +5630,12 @@ class Product extends CommonObject
 				while ($i < $num) {
 					$row = $this->db->fetch_object($result);
 					$this->stock_warehouse[$row->fk_entrepot] = new stdClass();
-					$this->stock_warehouse[$row->fk_entrepot]->real = $row->reel;
+					$this->stock_warehouse[$row->fk_entrepot]->real = price2num($row->reel, 'MS');
 					$this->stock_warehouse[$row->fk_entrepot]->id = $row->rowid;
 					if ((!preg_match('/nobatch/', $option)) && $this->hasbatch()) {
 						$this->stock_warehouse[$row->fk_entrepot]->detail_batch = Productbatch::findAll($this->db, $row->rowid, 1, $this->id);
 					}
-					$this->stock_reel += $row->reel;
+					$this->stock_reel += price2num($row->reel, 'MS');
 					$i++;
 				}
 			}


### PR DESCRIPTION
Fix compare on float when test on stock dont allow negative transfert (case when a stock is show at 2.20 but equal to 2.199999 in memory)

PR #24389
