### PR TITLE
CORE prelevement : Correction du test pour verifier si ICS est renseigner sur la banque lors de la creation d'un bon de prelevement

### DIFF
--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -172,7 +172,7 @@ if (empty($reshook)) {
 
 		require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
 		$bank = new Account($db);
-		$bank->fetch($conf->global->{$id_bankaccount});
+		$bank->fetch($id_bankaccount);
 		// ICS is not mandatory with payment by bank transfer
 		/*if ((empty($bank->ics) && $type !== 'bank-transfer')
 			|| (empty($bank->ics_transfer) && $type === 'bank-transfer')


### PR DESCRIPTION
Correction du test pour verifier si ICS est renseigner sur la banque lors de la creation d'un bon de prelevement