### PR TITLE
New variable to accept a deposit invoice as available credit even unpaid

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5526,8 +5526,7 @@ if ($action == 'create') {
 				}
 				// For deposit invoice
 				if ($object->type == Facture::TYPE_DEPOSIT && $usercancreate && $object->statut > Facture::STATUS_DRAFT && empty($discount->id)) {
-					if (price2num($object->total_ttc, 'MT') == price2num($sumofpaymentall, 'MT')) {
-						// We can close a down payment only if paid amount is same than amount of down payment (by definition)
+					if (price2num($object->total_ttc, 'MT') == price2num($sumofpaymentall, 'MT') || !empty($conf->global->DEPOSIT_AS_CREDIT_AVAILABLE_EVEN_UNPAID)) {
 						print '<a class="butAction'.($conf->use_javascript_ajax ? ' reposition' : '').'" href="'.$_SERVER["PHP_SELF"].'?facid='.$object->id.'&amp;action=converttoreduc">'.$langs->trans('ConvertToReduc').'</a>';
 					} else {
 						print '<span class="butActionRefused" title="'.$langs->trans("AmountPaidMustMatchAmountOfDownPayment").'">'.$langs->trans('ConvertToReduc').'</span>';


### PR DESCRIPTION
#26792
In many activities, the final invoice must be issued while the requested deposit has not yet been paid. Often it is the payment deadlines which generate this situation (for example in the finishing work)