### PR TITLE
CORE product: Backport support global PRODUCT_STOCK_LIST_SHOW_VIRTUAL_WITH_NO_PHYSICAL

### DIFF
--- a/htdocs/product/reassort.php
+++ b/htdocs/product/reassort.php
@@ -148,7 +148,44 @@ if (!empty($conf->global->PRODUCT_USE_UNITS)) {
 	$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_units as u on p.fk_unit = u.rowid';
 }
 $sql .= " WHERE p.entity IN (".getEntity('product').")";
-$sql .= " AND EXISTS (SELECT e.rowid FROM ".MAIN_DB_PREFIX."entrepot as e WHERE e.rowid = s.fk_entrepot AND e.entity IN (".getEntity('stock')."))";
+if (!getDolGlobalString('PRODUCT_STOCK_LIST_SHOW_VIRTUAL_WITH_NO_PHYSICAL')) {
+	$sql .= " AND EXISTS (SELECT e.rowid FROM ".MAIN_DB_PREFIX."entrepot as e WHERE e.rowid = s.fk_entrepot AND e.entity IN (".getEntity('stock')."))";
+} else {
+	$sql .= " AND
+		(
+			EXISTS
+				(SELECT e.rowid
+				 FROM ".MAIN_DB_PREFIX."entrepot as e
+				 WHERE e.rowid = s.fk_entrepot AND e.entity IN (".getEntity('stock')."))
+			OR (
+				SELECT SUM(cd1.qty) as qty
+				FROM ".MAIN_DB_PREFIX."commande_fournisseurdet as cd1
+				LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseur as c1
+					ON c1.rowid = cd1.fk_commande
+				WHERE c1.entity IN (1) AND cd1.fk_product = p.rowid AND c1.fk_statut in (3,4) AND cd1.qty <> 0
+			) IS NOT NULL
+			OR (
+				SELECT SUM(cd2.qty) as qty
+				FROM ".MAIN_DB_PREFIX."commandedet as cd2
+				LEFT JOIN ".MAIN_DB_PREFIX."commande as c2 ON c2.rowid = cd2.fk_commande
+				WHERE c2.entity IN (1) AND cd2.fk_product = p.rowid AND c2.fk_statut in (1,2) AND cd2.qty <> 0
+			) IS NOT NULL
+			OR (
+				SELECT SUM(ed3.qty) as qty
+				FROM ".MAIN_DB_PREFIX."expeditiondet as ed3
+				LEFT JOIN ".MAIN_DB_PREFIX."expedition as e3 ON e3.rowid = ed3.fk_expedition
+				LEFT JOIN ".MAIN_DB_PREFIX."commandedet as cd3 ON ed3.fk_origin_line = cd3.rowid
+				LEFT JOIN ".MAIN_DB_PREFIX."commande as c3 ON c3.rowid = cd3.fk_commande
+				WHERE e3.entity IN (1) AND cd3.fk_product = p.rowid AND c3.fk_statut IN (1,2) AND e3.fk_statut IN (1,2) AND ed3.qty <> 0
+			) IS NOT NULL
+			OR (
+				SELECT SUM(mp4.qty) as qty
+				FROM ".MAIN_DB_PREFIX."mrp_production as mp4
+				LEFT JOIN ".MAIN_DB_PREFIX."mrp_mo as m4 ON m4.rowid = mp4.fk_mo AND m4.entity IN (1) AND m4.status IN (1,2)
+				WHERE mp4.fk_product = p.rowid AND mp4.qty <> 0
+			) IS NOT NULL
+			) ";
+}
 if (!empty($search_categ) && $search_categ != '-1') {
 	$sql .= " AND ";
 	if ($search_categ == -2) {


### PR DESCRIPTION
Backport support global PRODUCT_STOCK_LIST_SHOW_VIRTUAL_WITH_NO_PHYSICAL
pour afficher aussi les produits qui ont un stock virtuel mais qui n'ont pas d'entrée stocks dans les entrepôts