### PR TITLE
Force VAT Rate to 20% on credit note with fix amount and 1 line  "Credit note"

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1561,6 +1561,11 @@ if (empty($reshook)) {
 								}
 
 								$descline .= ' - '.$srcobject->ref;
+
+								if(empty($tva)) {
+									$tva = getDolGlobalString('INVOICE_CREDIT_NOTE_DEFAULT_VAT_RATE', '20');
+								}
+
 								$result = $object->addline(
 									$descline,
 									$amount, // subprice


### PR DESCRIPTION
![Clipboard - 4 janvier 2024 09 43](https://github.com/Easya-Solutions/dolibarr/assets/2341395/9b616447-83cd-42f6-bd2f-be22b8b6aaff)
