### PR TITLE
FIX avoid from re-initializing result on nested hook getEntity

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -309,13 +309,15 @@ function getEntity($element, $shared = 1, $currentobject = null)
 		'currentobject' => $currentobject,
 		'out' => $out
 	);
-	$reshook = $hookmanager->executeHooks('hookGetEntity', $parameters, $currentobject, $action); // Note that $action and $object may have been modified by some hooks
+	// avoid from re-initializing results of previous hook (nested hooks)
+	$hookmanager2 = clone $hookmanager;
+	$reshook = $hookmanager2->executeHooks('hookGetEntity', $parameters, $currentobject, $action); // Note that $action and $object may have been modified by some hooks
 
 	if (is_numeric($reshook)) {
-		if ($reshook == 0 && !empty($hookmanager->resPrint)) {
-			$out .= ','.$hookmanager->resPrint; // add
+		if ($reshook == 0 && !empty($hookmanager2->resPrint)) {
+			$out .= ','.$hookmanager2->resPrint; // add
 		} elseif ($reshook == 1) {
-			$out = $hookmanager->resPrint; // replace
+			$out = $hookmanager2->resPrint; // replace
 		}
 	}
 


### PR DESCRIPTION
FIX avoid from re-initializing result on nested hook getEntity
- DLB : #27799