### PR TITLE
[CORE] PHP 8.2 Compat - Update DolibarrModules.class.php

### DIFF
--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -494,6 +494,9 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 				$sql = $val;
 				$ignoreerror = 0;
 				if (is_array($val)) {
+					if (empty($val['ignoreerror'])) {
+						$val['ignoreerror'] = '';
+					};
 					$sql = $val['sql'];
 					$ignoreerror = $val['ignoreerror'];
 				}


### PR DESCRIPTION
PHP 8.2 Compatibility - Initialize $val['ignoreerror']

I get errors when trying to deactivate and reactivate banking4dolibarr linked to this variable.