### PR TITLE
FIX user filter in per user view of event list

### DIFF
--- a/htdocs/comm/action/peruser.php
+++ b/htdocs/comm/action/peruser.php
@@ -921,6 +921,9 @@ while ($currentdaytoshow < $lastdaytoshow) {
 			$sql .= " WHERE u.entity IN (".getEntity('user').")";
 		}
 		$sql .= " AND u.statut = 1";
+		if ($filtert > 0) {
+			$sql .= " AND u.rowid = ".((int) $filtert);
+		}
 		if ($usergroup > 0)	{
 			$sql .= " AND ug.fk_usergroup = ".((int) $usergroup);
 		}


### PR DESCRIPTION
FIX user filter in per user view of event list
- DLB : #28049
- in "per user" view of event list, the user filter doesn't work (all users are still here)

**Before**
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/bf87309c-3de7-42ff-9aed-2d85fea9ba8c)

**After**
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/56efd4fe-45e9-4c95-bf1b-bed73d75fc5c)