### PR TITLE
FIX uses local resPrint instead of cloning hookmanager for nested hooks

### DIFF
--- a/htdocs/core/class/hookmanager.class.php
+++ b/htdocs/core/class/hookmanager.class.php
@@ -207,7 +207,7 @@ class HookManager
 		}
 
 		// Init return properties
-		$this->resPrint = '';
+		$localResPrint = '';
 		$this->resArray = array();
 		$this->resNbOfHooks = 0;
 
@@ -270,9 +270,9 @@ class HookManager
 						}
 						if (!empty($actionclassinstance->resprints)) {
 							if ($resactiontmp > 0) {
-								$this->resPrint = $actionclassinstance->resprints;
+								$localResPrint = $actionclassinstance->resprints;
 							} else {
-								$this->resPrint .= $actionclassinstance->resprints;
+								$localResPrint .= $actionclassinstance->resprints;
 							}
 						}
 					} else {
@@ -294,7 +294,7 @@ class HookManager
 							$this->resArray = array_merge($this->resArray, $actionclassinstance->results);
 						}
 						if (!empty($actionclassinstance->resprints)) {
-							$this->resPrint .= $actionclassinstance->resprints;
+							$localResPrint .= $actionclassinstance->resprints;
 						}
 						if (is_numeric($resactiontmp) && $resactiontmp < 0) {
 							$error++;
@@ -307,7 +307,7 @@ class HookManager
 						if (!is_array($resactiontmp) && !is_numeric($resactiontmp)) {
 							dol_syslog('Error: Bug into hook '.$method.' of module class '.get_class($actionclassinstance).'. Method must not return a string but an int (0=OK, 1=Replace, -1=KO) and set string into ->resprints', LOG_ERR);
 							if (empty($actionclassinstance->resprints)) {
-								$this->resPrint .= $resactiontmp;
+								$localResPrint .= $resactiontmp;
 							}
 						}
 					}
@@ -319,6 +319,8 @@ class HookManager
 				}
 			}
 		}
+
+		$this->resPrint = $localResPrint;
 
 		return ($error ? -1 : $resaction);
 	}

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -309,15 +309,13 @@ function getEntity($element, $shared = 1, $currentobject = null)
 		'currentobject' => $currentobject,
 		'out' => $out
 	);
-	// avoid from re-initializing results of previous hook (nested hooks)
-	$hookmanager2 = clone $hookmanager;
-	$reshook = $hookmanager2->executeHooks('hookGetEntity', $parameters, $currentobject, $action); // Note that $action and $object may have been modified by some hooks
+	$reshook = $hookmanager->executeHooks('hookGetEntity', $parameters, $currentobject, $action); // Note that $action and $object may have been modified by some hooks
 
 	if (is_numeric($reshook)) {
-		if ($reshook == 0 && !empty($hookmanager2->resPrint)) {
-			$out .= ','.$hookmanager2->resPrint; // add
+		if ($reshook == 0 && !empty($hookmanager->resPrint)) {
+			$out .= ','.$hookmanager->resPrint; // add
 		} elseif ($reshook == 1) {
-			$out = $hookmanager2->resPrint; // replace
+			$out = $hookmanager->resPrint; // replace
 		}
 	}
 


### PR DESCRIPTION
FIX uses local resPrint instead of cloning hookmanager for nested hooks
- DLB : #27799
- complete PR 710 : FIX avoid from re-initializing result on nested hook getEntity