### PR TITLE
TS2402-9010 - Correction du lien de paiement

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5721,11 +5721,9 @@ if ($action == 'create') {
 						// Sometimes we can receive more, so we accept to enter more and will offer a button to convert into discount (but it is not a credit note, just a prepayment done)
 						//print '<a class="butAction" href="'.DOL_URL_ROOT.'/compta/paiement.php?facid='.$object->id.'&amp;action=create&amp;accountid='.$object->fk_account.'">'.$langs->trans('DoPayment').'</a>';
 						$params['attr']['title'] = '';
-						if (isset($object->fk_account)) {
-						print dolGetButtonAction($langs->trans('DoPayment'), '', 'default', DOL_URL_ROOT.'/compta/paiement.php?facid='.$object->id.'&amp;action=create&amp;accountid='.$object->fk_account, '', true, $params);
-						} else {
-						print dolGetButtonAction($langs->trans('DoPayment'), '', 'default', DOL_URL_ROOT.'/compta/paiement.php?facid='.$object->id.'&amp;action=create', '', true, $params);
-						}
+						$payment_url = DOL_URL_ROOT.'/compta/paiement.php?facid='.$object->id.'&amp;action=create';
+						if (isset($object->fk_account)) $payment_url .= '&amp;accountid='.$object->fk_account ;
+						print dolGetButtonAction($langs->trans('DoPayment'), '', 'default', $payment_url, '', true, $params);
 					}
 				}
 			}

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5721,7 +5721,11 @@ if ($action == 'create') {
 						// Sometimes we can receive more, so we accept to enter more and will offer a button to convert into discount (but it is not a credit note, just a prepayment done)
 						//print '<a class="butAction" href="'.DOL_URL_ROOT.'/compta/paiement.php?facid='.$object->id.'&amp;action=create&amp;accountid='.$object->fk_account.'">'.$langs->trans('DoPayment').'</a>';
 						$params['attr']['title'] = '';
+						if (isset($object->fk_account)) {
 						print dolGetButtonAction($langs->trans('DoPayment'), '', 'default', DOL_URL_ROOT.'/compta/paiement.php?facid='.$object->id.'&amp;action=create&amp;accountid='.$object->fk_account, '', true, $params);
+						} else {
+						print dolGetButtonAction($langs->trans('DoPayment'), '', 'default', DOL_URL_ROOT.'/compta/paiement.php?facid='.$object->id.'&amp;action=create', '', true, $params);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Si on veut une valeur par défaut d'un compte bancaire dans les paiements : 
admin/defaultvalues.php 
compta/paiement.php -> accountid -> ValeurID de la banque souhaité

On se place sur une facture, le tiers n'a pas de banque par défaut, le lien vers le paiement est alors affublé d'un arguement vierge : &account= 
Ce qui fait que l'apparition du compte bancaire par défaut ne se passe pas sur la page suivante.
