### PR TITLE
FIX Payment on customer invoice - Remove accountid in url if empty for apply default value

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5510,7 +5510,7 @@ if ($action == 'create') {
 						print '<span class="butActionRefused" title="'.$langs->trans("DisabledBecauseRemainderToPayIsZero").'">'.$langs->trans('DoPayment').'</span>';
 					} else {
 						// Sometimes we can receive more, so we accept to enter more and will offer a button to convert into discount (but it is not a credit note, just a prepayment done)
-						print '<a class="butAction" href="'.DOL_URL_ROOT.'/compta/paiement.php?facid='.$object->id.'&amp;action=create&amp;accountid='.$object->fk_account.'">'.$langs->trans('DoPayment').'</a>';
+						print '<a class="butAction" href="'.DOL_URL_ROOT.'/compta/paiement.php?facid='.$object->id.'&amp;action=create'.($object->fk_account > 0 ? '&amp;accountid='.$object->fk_account : '').'">'.$langs->trans('DoPayment').'</a>';
 					}
 				}
 			}


### PR DESCRIPTION
#28156 for v18 fix

When we insert a payment in customer invoice, url contain and empty "accountid" if any bank account have been defined in customer invoice card.

![image](https://github.com/Easya-Solutions/dolibarr/assets/2341395/fd34641d-944d-4d6c-9f4e-add2de68c570)

If we want to use the default value function, accountid must not be present in the URL if it is empty.

![image](https://github.com/Easya-Solutions/dolibarr/assets/2341395/7c5563d3-1c7d-4a54-9c7a-c1bfcf29e1ac)

![image](https://github.com/Easya-Solutions/dolibarr/assets/2341395/a0e1e186-0f31-46f4-ac57-1db9bb9d4460)
