### PR TITLE
NEW: Add global STOCK_MOVEMENT_FORCE_DO_NOT_CLEAN_EMPTY_LINES to fore do not clean empty lines on movement stock

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -594,7 +594,7 @@ class MouvementStock extends CommonObject
 				}
 			}
 
-			if (empty($donotcleanemptylines)) {
+			if (empty($donotcleanemptylines) && !getDolGlobalInt('STOCK_MOVEMENT_FORCE_DO_NOT_CLEAN_EMPTY_LINES')) {
 				// If stock is now 0, we can remove entry into llx_product_stock, but only if there is no child lines into llx_product_batch (detail of batch, because we can imagine
 				// having a lot1/qty=X and lot2/qty=-X, so 0 but we must not loose repartition of different lot.
 				$sql = "DELETE FROM ".$this->db->prefix()."product_stock WHERE reel = 0 AND rowid NOT IN (SELECT fk_product_stock FROM ".$this->db->prefix()."product_batch as pb)";


### PR DESCRIPTION
Add global STOCK_MOVEMENT_FORCE_DO_NOT_CLEAN_EMPTY_LINES to fore do not clean empty lines on movement stock.

Because customer need to see the warehouse when the product previously even if the stock is at 0.
And when in the reassort page, the product with a stock at 0 don't display and block the repleinishment of the stock of the product.

PR #28170