### PR TITLE
NEW: Add global STOCK_MOVEMENT_FORCE_DO_NOT_CLEAN_EMPTY_LINES to fore do not clean empty lines on movement stock

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -577,11 +577,13 @@ class MouvementStock extends CommonObject
 				}
 			}
 
-			// If stock is now 0, we can remove entry into llx_product_stock, but only if there is no child lines into llx_product_batch (detail of batch, because we can imagine
-			// having a lot1/qty=X and lot2/qty=-X, so 0 but we must not loose repartition of different lot.
-			$sql = "DELETE FROM ".MAIN_DB_PREFIX."product_stock WHERE reel = 0 AND rowid NOT IN (SELECT fk_product_stock FROM ".MAIN_DB_PREFIX."product_batch as pb)";
-			$resql = $this->db->query($sql);
-			// We do not test error, it can fails if there is child in batch details
+			if (!getDolGlobalInt('STOCK_MOVEMENT_FORCE_DO_NOT_CLEAN_EMPTY_LINES')) {
+				// If stock is now 0, we can remove entry into llx_product_stock, but only if there is no child lines into llx_product_batch (detail of batch, because we can imagine
+				// having a lot1/qty=X and lot2/qty=-X, so 0 but we must not loose repartition of different lot.
+				$sql = "DELETE FROM " . MAIN_DB_PREFIX . "product_stock WHERE reel = 0 AND rowid NOT IN (SELECT fk_product_stock FROM " . MAIN_DB_PREFIX . "product_batch as pb)";
+				$resql = $this->db->query($sql);
+				// We do not test error, it can fails if there is child in batch details
+			}
 		}
 
 		// Add movement for sub products (recursive call)


### PR DESCRIPTION
Add global STOCK_MOVEMENT_FORCE_DO_NOT_CLEAN_EMPTY_LINES to fore do not clean empty lines on movement stock.

Because customer need to see the warehouse when the product previously even if the stock is at 0.
And when in the reassort page, the product with a stock at 0 don't display and block the repleinishment of the stock of the product.

PR #28170