### PR TITLE
CORE: Not trancate the multicurrency rate shown on cards

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5563,9 +5563,9 @@ class Form
 			print '</form>';
 		} else {
 			if (!empty($rate)) {
-				print price($rate, 1, $langs, 1, 0);
+				print price($rate, 1, $langs, 0, 0);
 				if ($currency && $rate != 1) {
-					print ' &nbsp; ('.price($rate, 1, $langs, 1, 0).' '.$currency.' = 1 '.$conf->currency.')';
+					print ' &nbsp; ('.price($rate, 1, $langs, 0, 0).' '.$currency.' = 1 '.$conf->currency.')';
 				}
 			} else {
 				print 1;


### PR DESCRIPTION
Not trancate the multicurrency rate shown on cards (even if the global MAIN_MAX_DECIMALS_SHOWN is set to 0)

Case when the user set prcision to shown to 0 and have a multicurrency rate at 0.0015245 (Example: XAF <=> EURO)

PR #28211
