### PR TITLE
Fix lost POST data when redirection after drag'n'drop in agenda

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -756,7 +756,7 @@ if (empty($reshook) && GETPOST('actionmove', 'alpha') == 'mupdate') {
 
 	$newdate = GETPOST('newdate', 'alpha');
 	if (empty($newdate) || strpos($newdate, 'dayevent_') != 0) {
-		header("Location: ".$backtopage);
+		header("Location: ".$backtopage, true, 307);
 		exit;
 	}
 
@@ -841,7 +841,7 @@ if (empty($reshook) && GETPOST('actionmove', 'alpha') == 'mupdate') {
 		}
 	}
 	if (!empty($backtopage)) {
-		header("Location: ".$backtopage);
+		header("Location: ".$backtopage, true, 307);
 		exit;
 	} else {
 		$action = '';


### PR DESCRIPTION
# Fix #[*#28212*]

Quand on drag'n'drop un événement dans l'agenda, lors de la redirection, nous perdons les données POST ce qui fait que nous perdons les filtres.
exemple:
avant le drag'n'drop:

![before](https://github.com/Easya-Solutions/dolibarr/assets/122890855/f0354896-f526-45df-92e7-fd8749a90a95)

après:

![after](https://github.com/Easya-Solutions/dolibarr/assets/122890855/c308eded-c3d1-4ce0-8030-670b06b24c7d)

La modification que je fais permet de garder les paramètres POST lors de la redirection