### PR TITLE
Fix des expeditions avec produit virtuel (kits)

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1617,9 +1617,7 @@ if ($action == 'create') {
 									print '<td class="left">';
 									if ($line->product_type == Product::TYPE_PRODUCT || !empty($conf->global->STOCK_SUPPORTS_SERVICES)) {
 										if ($product->stockable_product == Product::ENABLED_STOCK){
-											print $tmpwarehouseObject->getNomUrl(0).' ';
-											print '<!-- Show details of stock -->';
-											print '('.$stock.')';
+											print '';
 										} else {
 											print img_warning().' '.$langs->trans('StockDisabled') ;
 										}


### PR DESCRIPTION
# Fix
l'appel de `print $tmpwarehouseObject->getNomUrl(0).' ';` pose un problème, car `$tmpwarehouseObject` n'est pas déclaré à cet endroit du code.
Je me suis basé sur la PR [*#129*] pour corriger le problème.
Le problème a été introduit par [*#567*] avec le commit cherry-pick qui était basé sur une version 14 qui n'avait pas la PR 129 qui est easya only.