### PR TITLE
NEW selectionner les lignes pour un virement bancaire

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -510,7 +510,6 @@ if ($action == 'makepayment_confirm' && $user->hasRight('facture', 'paiement')) 
 				$rsql .= " , ".MAIN_DB_PREFIX."user as u";
 				$rsql .= " WHERE fk_facture = ".((int) $objecttmp->id);
 				$rsql .= " AND pfd.fk_user_demande = u.rowid";
-				$rsql .= " AND pfd.traite = 0";
 				$rsql .= " ORDER BY pfd.date_demande DESC";
 
 				$result_sql = $db->query($rsql);

--- a/htdocs/compta/facture/prelevement.php
+++ b/htdocs/compta/facture/prelevement.php
@@ -102,28 +102,33 @@ if ($reshook < 0) {
 }
 
 if (empty($reshook)) {
-	if ($action == "new" && $usercancreate) {
-		if ($object->id > 0) {
-			$db->begin();
+	if ($action == "new" && usercancreate) {
+		if (price2num(GETPOST('remaintopaylesspendingdebit', 'alpha')) > 0 && price2num(GETPOST('withdraw_request_amount', 'alpha')) <= price2num(GETPOST('remaintopaylesspendingdebit', 'alpha'))) {
+			if ($object->id > 0) {
+				$db->begin();
 
-			$newtype = $type;
-			$sourcetype = 'facture';
-			if ($type == 'bank-transfer') {
-				$sourcetype = 'supplier_invoice';
-				$newtype = 'bank-transfer';
+				$newtype = $type;
+				$sourcetype = 'facture';
+				if ($type == 'bank-transfer') {
+					$sourcetype = 'supplier_invoice';
+					$newtype = 'bank-transfer';
+				}
+				$paymentservice = GETPOST('paymentservice');
+
+				$result = $object->demande_prelevement($user, price2num(GETPOST('withdraw_request_amount', 'alpha')), $newtype, $sourcetype, GETPOST('iban', 'int'));
+				if ($result > 0) {
+					$db->commit();
+
+					setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
+				} else {
+					$db->rollback();
+					setEventMessages($object->error, $object->errors, 'errors');
+				}
 			}
-			$paymentservice = GETPOST('paymentservice');
-
-			$result = $object->demande_prelevement($user, price2num(GETPOST('withdraw_request_amount', 'alpha')), $newtype, $sourcetype);
-
-			if ($result > 0) {
-				$db->commit();
-
-				setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
-			} else {
-				$db->rollback();
-				setEventMessages($object->error, $object->errors, 'errors');
-			}
+			$action = '';
+		}
+		else {
+			setEventMessages($langs->trans('unprocessedRequest').' '.(price2num(GETPOST('remaintopaylesspendingdebit', 'alpha')) <= 0 ? $langs->trans('paymentsCoveringEntireInvoice') :  $langs->trans('requestedAmountExceedsOutstanding', price2num(GETPOST('withdraw_request_amount', 'alpha')), price2num(GETPOST('remaintopaylesspendingdebit', 'alpha')))), null, 'errors');
 		}
 		$action = '';
 	}
@@ -613,17 +618,35 @@ if ($object->id > 0) {
 	print '<tr><td>'.$langs->trans($title).'</td><td colspan="3">';
 
 	$bac = new CompanyBankAccount($db);
-	$bac->fetch(0, $object->thirdparty->id);
+	$sqliban	= 'SELECT rowid FROM '.MAIN_DB_PREFIX.'societe_rib WHERE fk_soc = '.$object->thirdparty->id;
+	$resqliban	= $db->query($sqliban);
+	if ($resqliban) {
+		$numiban	= $db->num_rows($resqliban);
+		print '<form method = "POST" action = "'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&type='.$type.'">';
+		print '<input type = "hidden" name = "action" value = "setiban">';
+		print '<input type = "hidden" name = "token" value="'.newToken().'">';
+		if ($numiban > 0) {
+			print '<select class = "flat quatrevingtpercent" id = "selectiban" name = "iban" style = "cursor: pointer;">';
+			for ($i = 0; $i < $numiban; $i++) {
+				$objiban	= $db->fetch_object($resqliban);
+				$bac->fetch($objiban->rowid);
+				$labelbac	= $bac->iban.(($bac->iban && $bac->bic) ? ' / ' : '').$bac->bic;
+				$selectediban = GETPOSTISSET('iban') ? GETPOST('iban', 'int') : (!empty($bac->default_rib) ? $objiban->rowid : '');
+				print '<option name = "selectiban" value = "'.$objiban->rowid.'"'.($selectediban == $objiban->rowid ? ' selected' : '').' >'.$labelbac.'</option>';
+			}
+			print '</select>';
+			print ajax_combobox('selectiban');
+			print '<input type = "submit" class = "button valignmiddle" value = "'.$langs->trans('Modify').'">';
+		} else {
+			if ($numopen || ($type != 'bank-transfer' && $object->mode_reglement_code == 'PRE') || ($type == 'bank-transfer' && $object->mode_reglement_code == 'VIR')) {
+			print img_warning($langs->trans('NoDefaultIBANFound'));
+			}
+		}
+		print '</form>';
 
-	print $bac->iban.(($bac->iban && $bac->bic) ? ' / ' : '').$bac->bic;
-	if (!empty($bac->iban)) {
-		if ($bac->verif() <= 0) {
-			print img_warning('Error on default bank number for IBAN : '.$bac->error_message);
-		}
+		$db->free($resqliban);
 	} else {
-		if ($numopen || ($type != 'bank-transfer' && $object->mode_reglement_code == 'PRE') || ($type == 'bank-transfer' && $object->mode_reglement_code == 'VIR')) {
-			print img_warning($langs->trans("NoDefaultIBANFound"));
-		}
+		dol_print_error($db);
 	}
 
 	print '</td></tr>';
@@ -724,8 +747,9 @@ if ($object->id > 0) {
 	} else {
 		$sql .= " WHERE fk_facture = ".((int) $object->id);
 	}
-	$sql .= " AND pfd.traite = 0";
+	// $sql .= " AND pfd.traite = 0";
 	$sql .= " AND pfd.type = 'ban'";
+	$sql .= " AND pfd.ext_payment_id IS NULL"; // TODO CHECK
 
 	$resql = $db->query($sql);
 	if ($resql) {
@@ -762,6 +786,8 @@ if ($object->id > 0) {
 				print '<input type="hidden" name="id" value="'.$object->id.'" />';
 				print '<input type="hidden" name="type" value="'.$type.'" />';
 				print '<input type="hidden" name="action" value="new" />';
+				print '<input type="hidden" name="iban" value="'.GETPOST('iban', 'int').'" />';	// InfraS add
+				print '<input type="hidden" name="remaintopaylesspendingdebit" value="'.$remaintopaylesspendingdebit.'" />';	// InfraS add
 				print '<label for="withdraw_request_amount">'.$langs->trans('BankTransferAmount').' </label>';
 				print '<input type="text" id="withdraw_request_amount" name="withdraw_request_amount" value="'.$remaintopaylesspendingdebit.'" size="9" />';
 				print '<input type="submit" class="butAction" value="'.$buttonlabel.'" />';

--- a/htdocs/compta/facture/prelevement.php
+++ b/htdocs/compta/facture/prelevement.php
@@ -102,7 +102,7 @@ if ($reshook < 0) {
 }
 
 if (empty($reshook)) {
-	if ($action == "new" && usercancreate) {
+	if ($action == "new" && $usercancreate) {
 		if (price2num(GETPOST('remaintopaylesspendingdebit', 'alpha')) > 0 && price2num(GETPOST('withdraw_request_amount', 'alpha')) <= price2num(GETPOST('remaintopaylesspendingdebit', 'alpha'))) {
 			if ($object->id > 0) {
 				$db->begin();

--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -840,7 +840,7 @@ class BonPrelevement extends CommonObject
 	 *  @param  string  $executiondate		Date to execute the transfer
 	 *  @param	int	    $notrigger			Disable triggers
 	 *  @param	string	$type				'direct-debit' or 'bank-transfer'
-	 *  @param	int | Aray[int]	$dids	ID(s) of existing payment request(s). If $did is defined, no entry. If $did is an array, the createdBonsPrelevement will include these apyment requests. 
+	 *  @param	int | Aray[int]	$dids	ID(s) of existing payment request(s). If $did is defined, no entry. If $did is an array, the createdBonsPrelevement will include these payment requests. 
 	 *  @param	int		$fk_bank_account	Bank account ID the receipt is generated for. Will use the ID into the setup of module Direct Debit or Credit Transfer if 0.
 	 * @param	Array(int)		$invoices	IDs of invoices to include;			
 	 *	@return	int							<0 if KO, No of invoice included into file if OK

--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -842,7 +842,6 @@ class BonPrelevement extends CommonObject
 	 *  @param	string	$type				'direct-debit' or 'bank-transfer'
 	 *  @param	int | Aray[int]	$dids	ID(s) of existing payment request(s). If $did is defined, no entry. If $did is an array, the createdBonsPrelevement will include these payment requests. 
 	 *  @param	int		$fk_bank_account	Bank account ID the receipt is generated for. Will use the ID into the setup of module Direct Debit or Credit Transfer if 0.
-	 * @param	Array(int)		$invoices	IDs of invoices to include;			
 	 *	@return	int							<0 if KO, No of invoice included into file if OK
 	 */
 	public function create($banque = 0, $agence = 0, $mode = 'real', $format = 'ALL', $executiondate = '', $notrigger = 0, $type = 'direct-debit', $dids = [], $fk_bank_account = 0)

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -284,6 +284,9 @@ if ($search_ref) {
 if ($search_ref) {
 	$searchsql .= natural_search('f.ref', $search_ref);
 }
+if ($search_ref_supplier) {
+	$searchsql .= natural_search('f.ref_supplier', $search_ref_supplier);
+}
 if ($search_company) {
 	$searchsql .= natural_search('s.nom', $search_company);
 }

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -735,7 +735,7 @@ if ($resql) {
 
 			// Amount
 			if (!empty($arrayfields['pfd.amount']['checked'])) {
-				print '<td class="right nowrap"><span class="amount">'.price($obj->amount)."</span></td>\n";
+				print '<td class="right nowrap"><span id="amount_'.$obj->request_row_id.'" class="amount">'.price($obj->amount)."</span></td>\n";
 				if (!$i) {
 					$totalarray['nbfield']++;
 					$totalarray['pos'][$totalarray['nbfield']] = 'pfd.amount';
@@ -816,7 +816,27 @@ if ($nb) {
 		$datere = $executiondate;
 		print $form->selectDate($datere, 're');
 
+		print '<span class="hideonsmartphone">'.$langs->trans('Total').' </span>';
+		print '<input id="total_checked" value=0 disabled>';
+		?>
+		<script>
 
+		function computeTotalChecked() {
+			let total_checked = 0;
+			let checked_pfd = Array.from($('[id^="cb"]').filter(':checked'));
+			checked_pfd.forEach((pfd) => {
+				let text_amount = $('[id^="amount_'+Number(pfd.value)+'"]').text()
+				let amount = Number(text_amount.replace(' ', '').replace(',', '.'))
+				total_checked += amount;
+			})
+			$('#total_checked').val(total_checked);
+		}
+
+		$('[id^="cb"]').change(computeTotalChecked);
+		computeTotalChecked();
+
+		</script>
+		<?php
 		if ($mysoc->isInEEC()) {
 			$title = $langs->trans("CreateForSepa");
 			if ($type == 'bank-transfer') {

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -468,7 +468,6 @@ if ($nb) {
 print "</form>\n";
 
 print "</div>\n";
-print '</form>';
 print '<br>';
 
 

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -196,6 +196,12 @@ if (empty($reshook)) {
 			$action = '';
 			$error++;
 		}
+		if (empty($toselect)) {
+			$mesg = $langs->trans("NoInvoiceSelected");
+			setEventMessages($mesg, null, 'errors');
+			$action = '';
+			$error++;
+		}
 
 
 		$bprev = new BonPrelevement($db);
@@ -203,8 +209,7 @@ if (empty($reshook)) {
 		if (!$error) {
 			// getDolGlobalString('PRELEVEMENT_CODE_BANQUE') and getDolGlobalString('PRELEVEMENT_CODE_GUICHET') should be empty (we don't use them anymore)
 			$selected_invoices = array();
-			if (!empty($toselect)) {
-				foreach($toselect as $select)
+			foreach($toselect as $select) {
 				$selected_invoices[] = (int) $select;
 			}
 			$result = $bprev->create(getDolGlobalString('PRELEVEMENT_CODE_BANQUE'), getDolGlobalString('PRELEVEMENT_CODE_GUICHET'), $mode, $format, $executiondate, 0, $type, $selected_invoices, $id_bankaccount);
@@ -634,7 +639,7 @@ if ($resql) {
 				if (in_array($obj->request_row_id, $arrayofselected) || empty($arrayofselected)) {
 					$selected = 1;
 				}
-				print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').'>';
+				print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').' amount="'.$obj->amount.'">';
 				print '</td>';
 			}
 
@@ -760,7 +765,7 @@ if ($resql) {
 				if (in_array($obj->request_row_id, $arrayofselected) || empty($arrayofselected)) {
 					$selected = 1;
 				}
-				print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').'>';
+				print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').' amount="'.$obj->amount.'">';
 				print '</td>';
 			}
 			print '</tr>';
@@ -829,8 +834,7 @@ if ($nb) {
 			let total_checked = 0;
 			let checked_pfd = Array.from($('[id^="cb"]').filter(':checked'));
 			checked_pfd.forEach((pfd) => {
-				let text_amount = $('[id^="amount_'+Number(pfd.value)+'"]').text()
-				let amount = Number(text_amount.replace(' ', '').replace(',', '.'))
+				let amount = Number(pfd.getAttribute('amount'));
 				total_checked += amount;
 			})
 			$('#total_checked').val(total_checked);

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -588,9 +588,7 @@ if ($resql) {
 
 	$varpage = empty($contextpage) ? $_SERVER["PHP_SELF"] : $contextpage;
 	$selectedfields = $form->multiSelectArrayWithCheckbox('selectedfields', $arrayfields, $varpage); // This also change content of $arrayfields
-	if ($massactionbutton) {
-		$selectedfields .= $form->showCheckAddButtons('checkforselect', 1);
-	}
+	$selectedfields .= $form->showCheckAddButtons('checkforselect', 1);
 
 	print '<table class="tagtable liste">';
 
@@ -652,9 +650,7 @@ if ($resql) {
 	print '<tr class="liste_titre">';
 	// Action column
 	if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
-		if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
-			print '<td align="center">'.$form->showCheckAddButtons('checkforselect', 1).'</td>';
-		}
+		print '<td align="center">'.$form->showCheckAddButtons('checkforselect', 1).'</td>';
 	}
 
 	if (!empty($arrayfields['f.ref']['checked'])) {
@@ -688,14 +684,6 @@ if ($resql) {
 
 	print "</tr>\n";
 
-	// Action column
-	if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
-		if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
-			print '<td align="center">'.$form->showCheckAddButtons('checkforselect', 1).'</td>';
-		}
-	}
-	print '</tr>';
-
 	if ($num) {
 		require_once DOL_DOCUMENT_ROOT.'/societe/class/companybankaccount.class.php';
 
@@ -723,13 +711,11 @@ if ($resql) {
 			// Action column
 			if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
 				print '<td class="nowrap center">';
-				if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
-					$selected = 0;
-					if (in_array($obj->request_row_id, $arrayofselected)) {
-						$selected = 1;
-					}
-					print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').'>';
+				$selected = 0;
+				if (in_array($obj->request_row_id, $arrayofselected) || empty($arrayofselected)) {
+					$selected = 1;
 				}
+				print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').'>';
 				print '</td>';
 			}
 
@@ -851,13 +837,11 @@ if ($resql) {
 			// Action column
 			if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
 				print '<td class="nowrap center">';
-				if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
-					$selected = 0;
-					if (in_array($obj->request_row_id, $arrayofselected)) {
-						$selected = 1;
-					}
-					print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').'>';
+				$selected = 0;
+				if (in_array($obj->request_row_id, $arrayofselected) || empty($arrayofselected)) {
+					$selected = 1;
 				}
+				print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').'>';
 				print '</td>';
 			}
 			print '</tr>';
@@ -868,11 +852,8 @@ if ($resql) {
 		include DOL_DOCUMENT_ROOT.'/core/tpl/list_print_total.tpl.php';
 
 	} else {
-		$colspan = 6;
+		$colspan = 7;
 		if ($type == 'bank-transfer') {
-			$colspan++;
-		}
-		if ($massactionbutton || $massaction) {
 			$colspan++;
 		}
 		print '<tr class="oddeven"><td colspan="'.$colspan.'"><span class="opacitymedium">'.$langs->trans("None").'</span></td></tr>';

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -6,6 +6,8 @@
  * Copyright (C) 2018       Nicolas ZABOURI         <info@inovea-conseil.com>
  * Copyright (C) 2018-2023  Frédéric France         <frederic.france@netlogic.fr>
  * Copyright (C) 2019       Markus Welters          <markus@welters.de>
+ * Copyright (C) 2024       Alexandre Spangaro      <aspangaro@open-dsi.fr>
+ * Copyright (C) 2024       Thomas Nerge     		<tnegre@open-dsi.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,26 +49,78 @@ $type = GETPOST('type', 'aZ09');
 $action = GETPOST('action', 'aZ09');
 $massaction = GETPOST('massaction', 'alpha'); // The bulk action (combo box choice into lists)
 $toselect   = GETPOST('toselect', 'array'); // Array of ids of elements selected into a list
+$contextpage = GETPOST('contextpage', 'aZ') ?GETPOST('contextpage', 'aZ') : 'directdebitcreatecard';
 
+// Security check
+if ($user->socid > 0) {
+	$action = '';
+	$_GET["action"] = '';
+	$socid = $user->socid;
+}
 $mode = GETPOST('mode', 'alpha') ?GETPOST('mode', 'alpha') : 'real';
 $format = GETPOST('format', 'aZ09');
 $id_bankaccount = GETPOST('id_bankaccount', 'int');
+$searchsql = GETPOST('searchsql', 'alpha');
 $executiondate = dol_mktime(0, 0, 0, GETPOST('remonth', 'int'), GETPOST('reday', 'int'), GETPOST('reyear', 'int'));
+
+$search_all 					= trim((GETPOST('search_all', 'alphanohtml') != '') ?GETPOST('search_all', 'alphanohtml') : GETPOST('sall', 'alphanohtml'));
+$search_ref 					= GETPOST('search_ref', 'alpha');
+$search_ref_supplier 			= GETPOST('search_ref_supplier', 'alpha');
+$search_datelimit_startday 		= GETPOST('search_datelimit_startday', 'int');
+$search_datelimit_startmonth 	= GETPOST('search_datelimit_startmonth', 'int');
+$search_datelimit_startyear 	= GETPOST('search_datelimit_startyear', 'int');
+$search_datelimit_endday 		= GETPOST('search_datelimit_endday', 'int');
+$search_datelimit_endmonth 		= GETPOST('search_datelimit_endmonth', 'int');
+$search_datelimit_endyear 		= GETPOST('search_datelimit_endyear', 'int');
+$search_datelimit_start 		= dol_mktime(0, 0, 0, $search_datelimit_startmonth, $search_datelimit_startday, $search_datelimit_startyear);
+$search_datelimit_end 			= dol_mktime(23, 59, 59, $search_datelimit_endmonth, $search_datelimit_endday, $search_datelimit_endyear);
+$search_company 				= GETPOST('search_company', 'alpha');
+$search_account 				= GETPOST('search_account', 'alpha');
+$toselect 						= GETPOST('toselect', 'array');
+$search_btn 					= GETPOST('button_search', 'alpha');
+$search_remove_btn 				= GETPOST('button_removefilter', 'alpha');
+
+$option = GETPOST('search_option');
+
+$filter = GETPOST('filtre', 'alpha');
 
 $limit = GETPOST('limit', 'int') ?GETPOST('limit', 'int') : $conf->liste_limit;
 $page = GETPOSTISSET('pageplusone') ? (GETPOST('pageplusone') - 1) : GETPOST("page", 'int');
-if (empty($page) || $page == -1) {
+if ($page == -1 || $page == null || !empty($search_btn) || !empty($search_remove_btn) || (empty($toselect) && $massaction === '0')) {
 	$page = 0;
 }     // If $page is not defined, or '' or -1
 $offset = $limit * $page;
+$pageprev = $page - 1;
+$pagenext = $page + 1;
+if (!$sortorder) {
+	$sortorder = "DESC";
+}
+if (!$sortfield) {
+	$sortfield = "f.date_lim_reglement,f.rowid";
+}
+
+// List of fields to search into when doing a "search in all"
+$fieldstosearchall = array(
+	'f.ref'=>'Ref',
+	's.nom'=>"ThirdParty",
+);
+
+$arrayfields = array(
+	'f.ref'=>array('label'=>($type == 'bank-transfer' ? 'SupplierInvoice' : 'Invoice'), 'checked'=>1),
+	'f.date_lim_reglement'=>array('label'=>"DateDue", 'checked'=>1),
+	's.nom'=>array('label'=>"ThirdParty", 'checked'=>1),
+	'f.fk_account'=>array('label'=>"BankAccount", 'checked'=>1),
+	'pfd.fk_soc_rib'=>array('label'=>"RIB", 'checked'=>1),
+	'rum'=>array('label'=>"RUM", 'checked'=>1),
+	'pfd.amount'=>array('label'=>"AmountTTC", 'checked'=>1),
+	'pfd.date_demande'=>array('label'=>"DateRequest", 'checked'=>1)
+);
+if ($type == 'bank-transfer') {
+	$arrayfields['f.ref_supplier'] = array('label'=>'RefSupplier', 'checked'=>1);
+}
 
 $hookmanager->initHooks(array('directdebitcreatecard', 'globalcard'));
 
-// Security check
-$socid = GETPOST('socid', 'int');
-if ($user->socid) {
-	$socid = $user->socid;
-}
 if ($type == 'bank-transfer') {
 	$result = restrictedArea($user, 'paymentbybanktransfer', '', '', '');
 } else {
@@ -93,6 +147,27 @@ if ($reshook < 0) {
 }
 
 if (empty($reshook)) {
+	include DOL_DOCUMENT_ROOT.'/core/actions_changeselectedfields.inc.php';
+
+	if (GETPOST('button_removefilter_x', 'alpha') || GETPOST('button_removefilter', 'alpha') || GETPOST('button_removefilter.x', 'alpha')) {		// All tests must be present to be compatible with all browsers
+		$search_all = "";
+		$search_ref = "";
+		$search_company = "";
+		$search_account = "";
+		$search_datelimit_startday = '';
+		$search_datelimit_startmonth = '';
+		$search_datelimit_startyear = '';
+		$search_datelimit_endday = '';
+		$search_datelimit_endmonth = '';
+		$search_datelimit_endyear = '';
+		$search_datelimit_start = '';
+		$search_datelimit_end = '';
+		$toselect = '';
+		$filter = '';
+		$option = '';
+		$socid = "";
+	}
+
 	// Change customer bank information to withdraw
 	if ($action == 'modify') {
 		for ($i = 1; $i < 9; $i++) {
@@ -127,7 +202,7 @@ if (empty($reshook)) {
 
 		if (!$error) {
 			// getDolGlobalString('PRELEVEMENT_CODE_BANQUE') and getDolGlobalString('PRELEVEMENT_CODE_GUICHET') should be empty (we don't use them anymore)
-			$result = $bprev->create(getDolGlobalString('PRELEVEMENT_CODE_BANQUE'), getDolGlobalString('PRELEVEMENT_CODE_GUICHET'), $mode, $format, $executiondate, 0, $type);
+			$result = $bprev->create(getDolGlobalString('PRELEVEMENT_CODE_BANQUE'), getDolGlobalString('PRELEVEMENT_CODE_GUICHET'), $mode, $format, $executiondate, 0, $type, $id_bankaccount, $searchsql);
 			if ($result < 0) {
 				setEventMessages($bprev->error, $bprev->errors, 'errors');
 			} elseif ($result == 0) {
@@ -160,7 +235,80 @@ if (empty($reshook)) {
 		$uploaddir = $conf->prelevement->dir_output;
 	}
 	include DOL_DOCUMENT_ROOT.'/core/actions_massactions.inc.php';
+	$arrayofselected = is_array($toselect) ? $toselect : array();
 }
+
+$sql = "SELECT f.ref, f.rowid, f.date_lim_reglement as datelimite, f.total_ttc, f.fk_account,";
+$sql .= " s.nom as name, s.rowid as socid,";
+$sql .= " pfd.rowid as request_row_id, pfd.date_demande, pfd.amount"; //, pfd.fk_soc_rib";
+if ($type == 'bank-transfer') {
+	$sql .= " FROM ".MAIN_DB_PREFIX."facture_fourn as f";
+} else {
+	$sql .= " FROM ".MAIN_DB_PREFIX."facture as f";
+}
+$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."bank_account AS ba ON f.fk_account = ba.rowid,";
+$sql .= " ".MAIN_DB_PREFIX."societe as s,";
+$sql .= " ".MAIN_DB_PREFIX."prelevement_demande as pfd";
+$sql .= " WHERE s.rowid = f.fk_soc";
+$sql .= " AND f.entity IN (".getEntity('invoice').")";
+if (empty($conf->global->WITHDRAWAL_ALLOW_ANY_INVOICE_STATUS)) {
+	$sql .= " AND f.fk_statut = ".Facture::STATUS_VALIDATED;
+}
+//$sql .= " AND pfd.amount > 0";
+$sql .= " AND f.total_ttc > 0"; // Avoid credit notes
+$sql .= " AND pfd.traite = 0";
+$sql .= " AND pfd.ext_payment_id IS NULL";
+if ($type == 'bank-transfer') {
+	$sql .= " AND pfd.fk_facture_fourn = f.rowid";
+} else {
+	$sql .= " AND pfd.fk_facture = f.rowid";
+}
+if ($socid > 0) {
+	$sql .= " AND f.fk_soc = ".((int) $socid);
+}
+$searchsql = '';
+if ($search_ref) {
+	if (is_numeric($search_ref)) {
+		$searchsql .= natural_search(array('f.ref'), $search_ref);
+	} else {
+		$searchsql .= natural_search('f.ref', $search_ref);
+	}
+}
+if ($search_ref) {
+	$searchsql .= natural_search('f.ref', $search_ref);
+}
+if ($search_company) {
+	$searchsql .= natural_search('s.nom', $search_company);
+}
+if ($search_account) {
+	$searchsql .= natural_search(array('ba.ref', 'ba.label', 'ba.bank'), $search_account);
+}
+if ($search_datelimit_start) {
+	$searchsql .= " AND f.date_lim_reglement >= '" . $db->idate($search_datelimit_start) . "'";
+}
+if ($search_datelimit_end) {
+	$searchsql .= " AND f.date_lim_reglement <= '" . $db->idate($search_datelimit_end) . "'";
+}
+if ($option == 'late') {
+	$searchsql .= " AND f.date_lim_reglement < '".$db->idate(dol_now() - $conf->facture->fournisseur->warning_delay)."'";
+}
+if ($filter && $filter != -1) {
+	$aFilter = explode(',', $filter);
+	foreach ($aFilter as $fil) {
+		$filt = explode(':', $fil);
+		$searchsql .= ' AND '.$db->escape(trim($filt[0]))." = '".$db->escape(trim($filt[1]))."'";
+	}
+}
+$sql .= !empty($searchsql) ? $searchsql : '';
+if (!$search_all) {
+	$sql .= " GROUP BY f.rowid, f.ref, f.date_lim_reglement,";
+	$sql .= ' s.rowid, s.nom';
+} else {
+	$sql .= natural_search(array_keys($fieldstosearchall), $search_all);
+	$searchsql .= natural_search(array_keys($fieldstosearchall), $search_all);
+}
+
+$sql .= $db->order($sortfield, $sortorder);
 
 
 /*
@@ -176,14 +324,6 @@ if ($type != 'bank-transfer') {
 	$invoicestatic = new FactureFournisseur($db);
 }
 $bprev = new BonPrelevement($db);
-$arrayofselected = is_array($toselect) ? $toselect : array();
-// List of mass actions available
-$arrayofmassactions = array(
-);
-if (GETPOST('nomassaction', 'int') || in_array($massaction, array('presend', 'predelete'))) {
-	$arrayofmassactions = array();
-}
-$massactionbutton = $form->selectMassAction('', $arrayofmassactions);
 
 if (prelevement_check_config($type) < 0) {
 	$langs->load("errors");
@@ -238,9 +378,10 @@ if ($mesg) {
 
 print '<div class="tabsAction">'."\n";
 
-print '<form action="'.$_SERVER['PHP_SELF'].'?action=create" method="POST">';
+print '<form action="'.$_SERVER['PHP_SELF'].'?action=create" method="POST" id="selectbank">';
 print '<input type="hidden" name="token" value="'.newToken().'">';
 print '<input type="hidden" name="type" value="'.$type.'">';
+print '<input type="hidden" name="searchsql" value="'.$searchsql.'">';
 if ($nb) {
 	if ($pricetowithdraw) {
 		$title = $langs->trans('BankToReceiveWithdraw').': ';
@@ -251,7 +392,6 @@ if ($nb) {
 		print img_picto('', 'bank_account');
 
 		$default_account = ($type == 'bank-transfer' ? 'PAYMENTBYBANKTRANSFER_ID_BANKACCOUNT' : 'PRELEVEMENT_ID_BANKACCOUNT');
-
 		print $form->select_comptes(getDolGlobalInt($default_account), 'id_bankaccount', 0, "courant=1", 0, '', 0, 'widthcentpercentminusx maxwidth300', 1);
 		print ' &nbsp; &nbsp; ';
 
@@ -335,42 +475,11 @@ print '<br>';
  * Invoices waiting for withdraw
  */
 
-$sql = "SELECT f.ref, f.rowid, f.total_ttc, s.nom as name, s.rowid as socid,";
-if ($type == 'bank-transfer') {
-	$sql .= " f.ref_supplier,";
-}
-$sql .= " pfd.rowid as request_row_id, pfd.date_demande, pfd.amount";
-if ($type == 'bank-transfer') {
-	$sql .= " FROM ".MAIN_DB_PREFIX."facture_fourn as f,";
-} else {
-	$sql .= " FROM ".MAIN_DB_PREFIX."facture as f,";
-}
-$sql .= " ".MAIN_DB_PREFIX."societe as s,";
-$sql .= " ".MAIN_DB_PREFIX."prelevement_demande as pfd";
-$sql .= " WHERE s.rowid = f.fk_soc";
-$sql .= " AND f.entity IN (".getEntity('invoice').")";
-if (empty($conf->global->WITHDRAWAL_ALLOW_ANY_INVOICE_STATUS)) {
-	$sql .= " AND f.fk_statut = ".Facture::STATUS_VALIDATED;
-}
-//$sql .= " AND pfd.amount > 0";
-$sql .= " AND f.total_ttc > 0"; // Avoid credit notes
-$sql .= " AND pfd.traite = 0";
-$sql .= " AND pfd.ext_payment_id IS NULL";
-if ($type == 'bank-transfer') {
-	$sql .= " AND pfd.fk_facture_fourn = f.rowid";
-} else {
-	$sql .= " AND pfd.fk_facture = f.rowid";
-}
-if ($socid > 0) {
-	$sql .= " AND f.fk_soc = ".((int) $socid);
-}
-
 $nbtotalofrecords = '';
 if (!getDolGlobalInt('MAIN_DISABLE_FULL_SCANLIST')) {
 	$result = $db->query($sql);
 	$nbtotalofrecords = $db->num_rows($result);
-	if (($page * $limit) > $nbtotalofrecords) {
-		// if total resultset is smaller then paging size (filtering), goto and load page 0
+	if (($page * $limit) > $nbtotalofrecords) { // if total resultset is smaller then paging size (filtering), goto and load page 0
 		$page = 0;
 		$offset = 0;
 	}
@@ -381,42 +490,165 @@ $sql .= $db->plimit($limit + 1, $offset);
 $resql = $db->query($sql);
 if ($resql) {
 	$num = $db->num_rows($resql);
-	$i = 0;
 
-	$param = '';
+	$arrayofselected = is_array($toselect) ? $toselect : array();
+
+	if ($socid) {
+		$soc = new Societe($db);
+		$soc->fetch($socid);
+		if (empty($search_company)) {
+			$search_company = $soc->name;
+		}
+	}
+
+	$param = '&socid='.$socid;
+	if (!empty($contextpage) && $contextpage != $_SERVER["PHP_SELF"]) {
+		$param .= '&contextpage='.urlencode($contextpage);
+	}
 	if ($limit > 0 && $limit != $conf->liste_limit) {
 		$param .= '&limit='.((int) $limit);
 	}
-	if ($socid) {
-		$param .= '&socid='.urlencode($socid);
+	if ($search_all) {
+		$param .= '&search_all='.urlencode($search_all);
+	}
+	if ($search_datelimit_startday) {
+		$param .= '&search_datelimit_startday='.urlencode($search_datelimit_startday);
+	}
+	if ($search_datelimit_startmonth) {
+		$param .= '&search_datelimit_startmonth='.urlencode($search_datelimit_startmonth);
+	}
+	if ($search_datelimit_startyear) {
+		$param .= '&search_datelimit_startyear='.urlencode($search_datelimit_startyear);
+	}
+	if ($search_datelimit_endday) {
+		$param .= '&search_datelimit_endday='.urlencode($search_datelimit_endday);
+	}
+	if ($search_datelimit_endmonth) {
+		$param .= '&search_datelimit_endmonth='.urlencode($search_datelimit_endmonth);
+	}
+	if ($search_datelimit_endyear) {
+		$param .= '&search_datelimit_endyear='.urlencode($search_datelimit_endyear);
+	}
+	if ($search_ref) {
+		$param .= '&search_ref='.urlencode($search_ref);
+	}
+	if ($search_company) {
+		$param .= '&search_company='.urlencode($search_company);
+	}
+	if ($search_account) {
+		$param .= '&search_account'.urlencode($search_account);
 	}
 	if ($option) {
-		$param .= "&option=".urlencode($option);
+		$param .= "&search_option=".urlencode($option);
 	}
+
+	// List of mass actions available
+	$arrayofmassactions = array(
+	);
+	if (in_array($massaction, array('presend', 'predelete'))) {
+		$arrayofmassactions = array();
+	}
+	$massactionbutton = $form->selectMassAction('', $arrayofmassactions);
+
+	$i = 0;
 
 	print '<form method="POST" id="searchFormList" action="'.$_SERVER["PHP_SELF"].'">';
 	print '<input type="hidden" name="token" value="'.newToken().'">';
-	print '<input type="hidden" name="page" value="'.$page.'">';
-	if (!empty($limit)) {
-		print '<input type="hidden" name="limit" value="'.$limit.'"/>';
-	}
-	if ($type != '') {
-		print '<input type="hidden" name="type" value="'.$type.'">';
-	}
+	print '<input type="hidden" name="sortfield" value="'.$sortfield.'">';
+	print '<input type="hidden" name="sortorder" value="'.$sortorder.'">';
+	print '<input type="hidden" name="type" value="'.$type.'">';
+	// print '<input type="hidden" name="page" value="'.$page.'">';
+	// if (!empty($limit)) {
+	// 	print '<input type="hidden" name="limit" value="'.$limit.'"/>';
+	// }
+	// if ($type != '') {
+	// 	print '<input type="hidden" name="type" value="'.$type.'">';
+	// }
 
 	$title = $langs->trans("InvoiceWaitingWithdraw");
 	if ($type == 'bank-transfer') {
 		$title = $langs->trans("InvoiceWaitingPaymentByBankTransfer");
 	}
-	print_barre_liste($title, $page, $_SERVER['PHP_SELF'], $param, '', '', $massactionbutton, $num, $nbtotalofrecords, 'bill', 0, '', '', $limit);
+	print_barre_liste($title, $page, $_SERVER['PHP_SELF'], $param, $sortfield, $sortorder, $massactionbutton, $num, $nbtotalofrecords, 'bill', 0, '', '', $limit, 0, 0, 1);
 
-	$tradinvoice = "Invoice";
-	if ($type == 'bank-transfer') {
-		$tradinvoice = "SupplierInvoice";
-	}
+	// $tradinvoice = "Invoice";
+	// if ($type == 'bank-transfer') {
+	// 	$tradinvoice = "SupplierInvoice";
+	// }
 
 	print '<div class="div-table-responsive-no-min">';
 	print '<table class="noborder centpercent">';
+
+	if ($search_all) {
+		foreach ($fieldstosearchall as $key => $val) {
+			$fieldstosearchall[$key] = $langs->trans($val);
+		}
+		print '<div class="divsearchfieldfilter">'.$langs->trans("FilterOnInto", $search_all).join(', ', $fieldstosearchall).'</div>';
+	}
+
+	$varpage = empty($contextpage) ? $_SERVER["PHP_SELF"] : $contextpage;
+	$selectedfields = $form->multiSelectArrayWithCheckbox('selectedfields', $arrayfields, $varpage); // This also change content of $arrayfields
+	if ($massactionbutton) {
+		$selectedfields .= $form->showCheckAddButtons('checkforselect', 1);
+	}
+
+	print '<table class="tagtable liste">';
+
+	// Line for filters
+	print '<tr class="liste_titre_filter">';
+	// Ref
+	if (!empty($arrayfields['f.ref']['checked'])) {
+		print '<td class="liste_titre left">';
+		print '<input class="flat maxwidth50" type="text" name="search_ref" value="'.$search_ref.'">';
+		print '</td>';
+	}
+	// Ref suppllier
+	if (!empty($arrayfields['f.ref_supplier']['checked'])) {
+		print '<td class="liste_titre left">';
+		print '<input class="flat maxwidth50" type="text" name="search_ref_supplier" value="'.$search_ref_supplier.'">';
+		print '</td>';
+	}
+	// Date due
+	if (!empty($arrayfields['f.date_lim_reglement']['checked'])) {
+		print '<td class="liste_titre center">';
+		print '<div class="nowrap">';
+		print $form->selectDate($search_datelimit_end ? $search_datelimit_end : -1, 'search_datelimit_end', 0, 0, 1, '', 1, 0, 0, '', '', '', '', 1, '', $langs->trans("Before"));
+		print '<br><input type="checkbox" name="search_option" value="late"'.($option == 'late' ? ' checked' : '').'> '.$langs->trans("Alert");
+		print '</div>';
+		print '</td>';
+	}
+	// Thirpdarty
+	if (!empty($arrayfields['s.nom']['checked'])) {
+		print '<td class="liste_titre"><input class="flat maxwidth50" type="text" name="search_company" value="'.$search_company.'"></td>';
+	}
+	// bank account
+	if (!empty($arrayfields['f.fk_account']['checked'])) {
+		print '<td class="liste_titre"><input class="flat maxwidth50" type="text" name="search_account" value="'.$search_account.'"></td>';
+	}
+	// RIB
+	if (!empty($arrayfields['pfd.fk_soc_rib']['checked'])) {
+		print '<td class="liste_titre">&nbsp;</td>';
+	}
+	// RUM
+	if (!empty($arrayfields['rum']['checked'])) {
+		print '<td class="liste_titre">&nbsp;</td>';
+	}
+	// Amount
+	if (!empty($arrayfields['pfd.amount']['checked'])) {
+		print '<td class="liste_titre">&nbsp;</td>';
+	}
+	// Date request
+	if (!empty($arrayfields['pfd.date_demande']['checked'])) {
+		print '<td class="liste_titre">&nbsp;</td>';
+	}
+	// Action column
+	print '<td class="liste_titre middle">';
+	$searchpicto = $form->showFilterButtons();
+	print $searchpicto;
+	print '</td>';
+
+	print "</tr>\n";
+
 	print '<tr class="liste_titre">';
 	// Action column
 	if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
@@ -424,15 +656,38 @@ if ($resql) {
 			print '<td align="center">'.$form->showCheckAddButtons('checkforselect', 1).'</td>';
 		}
 	}
-	print '<td>'.$langs->trans($tradinvoice).'</td>';
-	if ($type == 'bank-transfer') {
-		print '<td>'.$langs->trans("RefSupplier").'</td>';
+
+	if (!empty($arrayfields['f.ref']['checked'])) {
+		print_liste_field_titre($arrayfields['f.ref']['label'], $_SERVER['PHP_SELF'], 'f.ref,f.rowid', '', $param, '', $sortfield, $sortorder);
 	}
-	print '<td>'.$langs->trans("ThirdParty").'</td>';
-	print '<td>'.$langs->trans("RIB").'</td>';
-	print '<td>'.$langs->trans("RUM").'</td>';
-	print '<td class="right">'.$langs->trans("AmountTTC").'</td>';
-	print '<td class="right">'.$langs->trans("DateRequest").'</td>';
+	if ($type == 'bank-transfer' && !empty($arrayfields['f.ref_supplier']['checked'])) {
+		print_liste_field_titre($arrayfields['f.ref_supplier']['label'], $_SERVER['PHP_SELF'], 'f.ref_supplier,f.rowid', '', $param, '', $sortfield, $sortorder);
+	}
+	if (!empty($arrayfields['f.date_lim_reglement']['checked'])) {
+		print_liste_field_titre($arrayfields['f.date_lim_reglement']['label'], $_SERVER['PHP_SELF'], 'f.date_lim_reglement', '', $param, '', $sortfield, $sortorder, 'center ');
+	}
+	if (!empty($arrayfields['s.nom']['checked'])) {
+		print_liste_field_titre($arrayfields['s.nom']['label'], $_SERVER['PHP_SELF'], 's.nom', '', $param, '', $sortfield, $sortorder);
+	}
+	if (!empty($arrayfields['f.fk_account']['checked'])) {
+		print_liste_field_titre($arrayfields['f.fk_account']['label'], $_SERVER['PHP_SELF'], 'f.fk_account', '', $param, '', $sortfield, $sortorder);
+	}
+	if (!empty($arrayfields['pfd.fk_soc_rib']['checked'])) {
+		print_liste_field_titre($arrayfields['pfd.fk_soc_rib']['label'], $_SERVER['PHP_SELF'], 'pfd.fk_soc_rib', '', $param, '', $sortfield, $sortorder);
+	}
+	if (!empty($arrayfields['rum']['checked'])) {
+		print_liste_field_titre($arrayfields['rum']['label'], $_SERVER['PHP_SELF'], '', '', $param, '', $sortfield, $sortorder);
+	}
+	if (!empty($arrayfields['pfd.amount']['checked'])) {
+		print_liste_field_titre($arrayfields['pfd.amount']['label'], $_SERVER['PHP_SELF'], 'pfd.amount', '', $param, '', $sortfield, $sortorder, 'right');
+	}
+	if (!empty($arrayfields['pfd.date_demande']['checked'])) {
+		print_liste_field_titre($arrayfields['pfd.date_demande']['label'], $_SERVER['PHP_SELF'], 'pfd.date_demande', '', $param, '', $sortfield, $sortorder, 'center ');
+	}
+	print_liste_field_titre($selectedfields, $_SERVER['PHP_SELF'], '', '', '', '', $sortfield, $sortorder, 'center maxwidthsearch ');
+
+	print "</tr>\n";
+
 	// Action column
 	if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
 		if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
@@ -448,7 +703,16 @@ if ($resql) {
 			$obj = $db->fetch_object($resql);
 
 			$bac = new CompanyBankAccount($db);	// Must include the new in loop so the fetch is clean
-			$bac->fetch(0, $obj->socid);
+			// $bac->fetch(0, $obj->socid);
+			$datelimit = $db->jdate($obj->datelimite);
+			$invoicestatic->fetch($obj->rowid);
+			$thirdpartystatic->fetch($obj->socid);
+
+			if (!empty($obj->fk_soc_rib)) {
+				$bac->fetch($obj->fk_soc_rib);
+			} else {
+				$bac->fetch(0, $obj->socid);
+			}
 
 			$invoicestatic->id = $obj->rowid;
 			$invoicestatic->ref = $obj->ref;
@@ -458,88 +722,151 @@ if ($resql) {
 
 			// Action column
 			if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
+				print '<td class="nowrap center">';
 				if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
-					print '<td class="nowrap center">';
 					$selected = 0;
 					if (in_array($obj->request_row_id, $arrayofselected)) {
 						$selected = 1;
 					}
 					print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').'>';
-					print '</td>';
 				}
-			}
-
-			// Ref invoice
-			print '<td class="tdoverflowmax150">';
-			print $invoicestatic->getNomUrl(1, 'withdraw');
-			print '</td>';
-
-			if ($type == 'bank-transfer') {
-				print '<td class="tdoverflowmax100" title="'.dol_escape_htmltag($invoicestatic->ref_supplier).'">';
-				print dol_escape_htmltag($invoicestatic->ref_supplier);
 				print '</td>';
 			}
 
-			// Thirdparty
-			print '<td class="tdoverflowmax100">';
-			$thirdpartystatic->fetch($obj->socid);
-			print $thirdpartystatic->getNomUrl(1, 'ban');
-			print '</td>';
+			// Ref invoice
+			if (!empty($arrayfields['f.ref']['checked'])) {
+				print '<td class="tdoverflowmax150">';
+				print $invoicestatic->getNomUrl(1, 'withdraw', 0, 0, '', 0, -1, 1);
+				print "</td>\n";
+				if (!$i) {
+					$totalarray['nbfield']++;
+				}
+			}
+
+			// Ref supplier
+			if (!empty($arrayfields['f.ref_supplier']['checked'])) {
+				print '<td class="tdoverflowmax100" title="'.dol_escape_htmltag($invoicestatic->ref_supplier).'">';
+				print dol_escape_htmltag($invoicestatic->ref_supplier);
+				print "</td>\n";
+				if (!$i) {
+					$totalarray['nbfield']++;
+				}
+			}
+
+			// Date limit
+			if (!empty($arrayfields['f.date_lim_reglement']['checked'])) {
+				print '<td class="center nowraponall">'.dol_print_date($datelimit, 'day');
+				if ($invoicestatic->hasDelay()) {
+					print img_warning($langs->trans('Alert').' - '.$langs->trans('Late'));
+				}
+				print '</td>';
+				if (!$i) {
+					$totalarray['nbfield']++;
+				}
+			}
+
+			// Third party
+			if (!empty($arrayfields['s.nom']['checked'])) {
+				print '<td class="tdoverflowmax200">';
+				$thirdpartystatic->fetch($obj->socid);
+				print $thirdpartystatic->getNomUrl(1, 'ban');
+				print '</td>';
+				if (!$i) {
+					$totalarray['nbfield']++;
+				}
+			}
+
+			// Bank account
+			if (!empty($arrayfields['f.fk_account']['checked'])) {
+				if (!empty($obj->fk_account)) {
+					$bankaccountstatic->fetch($obj->fk_account);
+					print '<td class="tdoverflowmax200">'.$bankaccountstatic->getNomUrl(1);
+					print '<input type="hidden" name="account_searched" value="'.$obj->fk_account.'">';
+					print "</td>\n";
+				}
+				else	print '<td class="tdoverflowmax200">&nbsp;</td>'."\n";
+				if (!$i) {
+					$totalarray['nbfield']++;
+				}
+			}
 
 			// RIB
-			print '<td>';
-			if ($bac->id > 0) {
-				if (!empty($bac->iban) || !empty($bac->bic)) {
-					print $bac->iban.(($bac->iban && $bac->bic) ? ' / ' : '').$bac->bic;
-					if ($bac->verif() <= 0) {
-						print img_warning('Error on default bank number for IBAN : '.$langs->trans($bac->error_message));
+			if (!empty($arrayfields['pfd.fk_soc_rib']['checked'])) {
+				print '<td>';
+				if ($bac->id > 0) {
+					if (!empty($bac->iban) || !empty($bac->bic)) {
+						print $bac->iban.(($bac->iban && $bac->bic) ? ' / ' : '').$bac->bic;
+						if ($bac->verif() <= 0) {
+							print img_warning('Error on default bank number for IBAN : '.$langs->trans($bac->error_message));
+						}
+					} else {
+						print img_warning($langs->trans("IBANNotDefined"));
 					}
 				} else {
-					print img_warning($langs->trans("IBANNotDefined"));
+					print img_warning($langs->trans("NoBankAccountDefined"));
 				}
-			} else {
-				print img_warning($langs->trans("NoBankAccountDefined"));
+				print '</td>';
+				if (!$i) {
+					$totalarray['nbfield']++;
+				}
 			}
-			print '</td>';
 
 			// RUM
-			print '<td>';
-			$rumtoshow = $thirdpartystatic->display_rib('rum');
-			if ($rumtoshow) {
-				print $rumtoshow;
-				$format = $thirdpartystatic->display_rib('format');
-				if ($type != 'bank-transfer') {
-					if ($format) {
-						print ' ('.$format.')';
+			if (!empty($arrayfields['rum']['checked'])) {
+				print '<td>';
+				$rumtoshow = $thirdpartystatic->display_rib('rum');
+				if ($rumtoshow) {
+					print $rumtoshow;
+					$format = $thirdpartystatic->display_rib('format');
+					if ($type != 'bank-transfer') {
+						if ($format) {
+							print ' ('.$format.')';
+						}
 					}
+				} else {
+					print img_warning($langs->trans("NoBankAccountDefined"));
 				}
-			} else {
-				print img_warning($langs->trans("NoBankAccountDefined"));
+				print '</td>';
+				if (!$i) {
+					$totalarray['nbfield']++;
+				}
 			}
-			print '</td>';
+
 			// Amount
-			print '<td class="right amount">';
-			print price($obj->amount, 0, $langs, 0, 0, -1, $conf->currency);
-			print '</td>';
+			if (!empty($arrayfields['pfd.amount']['checked'])) {
+				print '<td class="right nowrap"><span class="amount">'.price($obj->amount)."</span></td>\n";
+				if (!$i) {
+					$totalarray['nbfield']++;
+					$totalarray['pos'][$totalarray['nbfield']] = 'pfd.amount';
+				}
+				$totalarray['val']['pfd.amount'] += $obj->amount;
+			}
 			// Date
-			print '<td class="right">';
-			print dol_print_date($db->jdate($obj->date_demande), 'day');
-			print '</td>';
+			if (!empty($arrayfields['pfd.date_demande']['checked'])) {
+				print '<td class="center nowraponall">'.dol_print_date($db->jdate($obj->date_demande), 'day').'</td>';
+				if (!$i) {
+					$totalarray['nbfield']++;
+				}
+			}
 			// Action column
 			if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
+				print '<td class="nowrap center">';
 				if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
-					print '<td class="nowrap center">';
 					$selected = 0;
 					if (in_array($obj->request_row_id, $arrayofselected)) {
 						$selected = 1;
 					}
 					print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').'>';
-					print '</td>';
 				}
+				print '</td>';
 			}
 			print '</tr>';
 			$i++;
 		}
+
+		// Show total line
+		include DOL_DOCUMENT_ROOT.'/core/tpl/list_print_total.tpl.php';
+
 	} else {
 		$colspan = 6;
 		if ($type == 'bank-transfer') {
@@ -550,6 +877,9 @@ if ($resql) {
 		}
 		print '<tr class="oddeven"><td colspan="'.$colspan.'"><span class="opacitymedium">'.$langs->trans("None").'</span></td></tr>';
 	}
+
+	$db->free($resql);
+
 	print "</table>";
 	print "</div>";
 
@@ -559,62 +889,6 @@ if ($resql) {
 	dol_print_error($db);
 }
 
-
-/*
- * List of latest withdraws
- */
-/*
-$limit=5;
-
-print load_fiche_titre($langs->trans("LastWithdrawalReceipts",$limit),'','');
-
-$sql = "SELECT p.rowid, p.ref, p.amount, p.statut";
-$sql.= ", p.datec";
-$sql.= " FROM ".MAIN_DB_PREFIX."prelevement_bons as p";
-$sql.= " WHERE p.entity IN (".getEntity('invoice').")";
-$sql.= " ORDER BY datec DESC";
-$sql.=$db->plimit($limit);
-
-$result = $db->query($sql);
-if ($result)
-{
-	$num = $db->num_rows($result);
-	$i = 0;
-
-	print"\n<!-- debut table -->\n";
-	print '<table class="noborder centpercent">';
-	print '<tr class="liste_titre"><td>'.$langs->trans("Ref").'</td>';
-	print '<td class="center">'.$langs->trans("Date").'</td><td class="right">'.$langs->trans("Amount").'</td>';
-	print '</tr>';
-
-	while ($i < min($num,$limit))
-	{
-		$obj = $db->fetch_object($result);
-
-
-		print '<tr class="oddeven">';
-
-		print "<td>";
-		$bprev->id=$obj->rowid;
-		$bprev->ref=$obj->ref;
-		print $bprev->getNomUrl(1);
-		print "</td>\n";
-
-		print '<td class="center">'.dol_print_date($db->jdate($obj->datec),'day')."</td>\n";
-
-		print '<td class="right"><span class="amount">'.price($obj->amount,0,$langs,0,0,-1,$conf->currency)."</span></td>\n";
-
-		print "</tr>\n";
-		$i++;
-	}
-	print "</table><br>";
-	$db->free($result);
-}
-else
-{
-	dol_print_error($db);
-}
-*/
 
 // End of page
 llxFooter();

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -472,6 +472,7 @@ if ($resql) {
 	print '<input type="hidden" name="sortfield" value="'.$sortfield.'">';
 	print '<input type="hidden" name="sortorder" value="'.$sortorder.'">';
 	print '<input type="hidden" name="type" value="'.$type.'">';
+	print '<input type="hidden" name="formfilteraction" id="formfilteraction" value="list">';
 	// print '<input type="hidden" name="page" value="'.$page.'">';
 	// if (!empty($limit)) {
 	// 	print '<input type="hidden" name="limit" value="'.$limit.'"/>';

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -787,9 +787,6 @@ if ($resql) {
 
 print '<div class="tabsAction">'."\n";
 
-// print '<form action="'.$_SERVER['PHP_SELF'].'?action=create" method="POST" id="selectbank">';
-// print '<input type="hidden" name="token" value="'.newToken().'">';
-// print '<input type="hidden" name="type" value="'.$type.'">';
 print '<input type="hidden" name="searchsql" value="'.$searchsql.'">';
 if ($nb) {
 	if ($pricetowithdraw) {
@@ -832,7 +829,6 @@ if ($nb) {
 				print '<option value="RCUR"'.($format == 'RCUR' ? ' selected="selected"' : '').'>'.$langs->trans('SEPARCUR').'</option>';
 				print '</select>';
 			}
-			// print '<input type="submit" class="butAction margintoponly maringbottomonly" value="'.$title.'"/>';
 			print '<button type="submit" class="butAction margintoponly maringbottomonly" name="action" value="create">'.$title.'</button>'."\n";
 		} else {
 			$title = $langs->trans("CreateAll");
@@ -840,7 +836,6 @@ if ($nb) {
 				$title = $langs->trans("CreateFileForPaymentByBankTransfer");
 			}
 			print '<input type="hidden" name="format" value="ALL">'."\n";
-			// print '<input type="submit" class="butAction margintoponly maringbottomonly" value="'.$title.'">'."\n";
 			print '<button type="submit" class="butAction margintoponly maringbottomonly" name="action" value="create">'.$title.'</button>'."\n";
 		}
 	} else {

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -242,6 +242,7 @@ $sql = "SELECT f.ref, f.rowid, f.date_lim_reglement as datelimite, f.total_ttc, 
 $sql .= " s.nom as name, s.rowid as socid,";
 $sql .= " pfd.rowid as request_row_id, pfd.date_demande, pfd.amount"; //, pfd.fk_soc_rib";
 if ($type == 'bank-transfer') {
+	$sql .= " , ref_supplier";
 	$sql .= " FROM ".MAIN_DB_PREFIX."facture_fourn as f";
 } else {
 	$sql .= " FROM ".MAIN_DB_PREFIX."facture as f";

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2018-2023  Frédéric France         <frederic.france@netlogic.fr>
  * Copyright (C) 2019       Markus Welters          <markus@welters.de>
  * Copyright (C) 2024       Alexandre Spangaro      <aspangaro@open-dsi.fr>
- * Copyright (C) 2024       Thomas Nerge     		<tnegre@open-dsi.fr>
+ * Copyright (C) 2024       Thomas Negre     		<tnegre@open-dsi.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -838,7 +838,7 @@ if ($nb) {
 				let amount = Number(pfd.getAttribute('amount'));
 				total_checked += amount;
 			})
-			$('#total_checked').val(total_checked);
+			$('#total_checked').val(Math.round(total_checked * 100) / 100.0);
 		}
 
 		$('[id^="cb"]').change(computeTotalChecked);

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -838,7 +838,8 @@ if ($nb) {
 				let amount = Number(pfd.getAttribute('amount'));
 				total_checked += amount;
 			})
-			$('#total_checked').val(Math.round(total_checked * 100) / 100.0);
+			let precision = Number(10^<?= getDolGlobalInt('MAIN_MAX_DECIMALS_TOT') ?>)
+			$('#total_checked').val(Math.round(total_checked * precision) / precision);
 		}
 
 		$('[id^="cb"]').change(computeTotalChecked);

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -838,7 +838,7 @@ if ($nb) {
 				let amount = Number(pfd.getAttribute('amount'));
 				total_checked += amount;
 			})
-			let precision = Number(10^<?= getDolGlobalInt('MAIN_MAX_DECIMALS_TOT') ?>)
+			let precision = Math.pow(10, <?= getDolGlobalInt('MAIN_MAX_DECIMALS_TOT') ?>);
 			$('#total_checked').val(Math.round(total_checked * precision) / precision);
 		}
 

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -614,6 +614,7 @@ if ($resql) {
 		while ($i < $num && $i < $limit) {
 			$obj = $db->fetch_object($resql);
 
+			$bankaccountstatic = new Account($db);
 			$bac = new CompanyBankAccount($db);	// Must include the new in loop so the fetch is clean
 			// $bac->fetch(0, $obj->socid);
 			$datelimit = $db->jdate($obj->datelimite);

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -574,7 +574,7 @@ if ($resql) {
 	print '<tr class="liste_titre">';
 	// Action column
 	if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
-		print '<td align="center">'.$form->showCheckAddButtons('checkforselect', 1).'</td>';
+		print_liste_field_titre($selectedfields, $_SERVER['PHP_SELF'], '', '', '', '', $sortfield, $sortorder, 'center maxwidthsearch ');
 	}
 
 	if (!empty($arrayfields['f.ref']['checked'])) {
@@ -604,7 +604,9 @@ if ($resql) {
 	if (!empty($arrayfields['pfd.date_demande']['checked'])) {
 		print_liste_field_titre($arrayfields['pfd.date_demande']['label'], $_SERVER['PHP_SELF'], 'pfd.date_demande', '', $param, '', $sortfield, $sortorder, 'center ');
 	}
-	print_liste_field_titre($selectedfields, $_SERVER['PHP_SELF'], '', '', '', '', $sortfield, $sortorder, 'center maxwidthsearch ');
+	if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
+		print_liste_field_titre($selectedfields, $_SERVER['PHP_SELF'], '', '', '', '', $sortfield, $sortorder, 'center maxwidthsearch ');
+	}
 
 	print "</tr>\n";
 

--- a/htdocs/langs/en_US/withdrawals.lang
+++ b/htdocs/langs/en_US/withdrawals.lang
@@ -32,6 +32,7 @@ InvoiceWaitingWithdraw=Invoice waiting for direct debit
 InvoiceWaitingPaymentByBankTransfer=Invoice waiting for credit transfer
 AmountToWithdraw=Amount to withdraw
 AmountToTransfer=Amount to transfer
+NoInvoiceSelected=No invoice selected.
 NoInvoiceToWithdraw=No invoice open for '%s' is waiting. Go on tab '%s' on invoice card to make a request.
 NoSupplierInvoiceToWithdraw=No supplier invoice with open '%s' is waiting. Go on tab '%s' on invoice card to make a request.
 ResponsibleUser=User Responsible

--- a/htdocs/langs/en_US/withdrawals.lang
+++ b/htdocs/langs/en_US/withdrawals.lang
@@ -161,3 +161,6 @@ TotalAmountOfdirectDebitOrderDiffersFromSumOfLines=Total amount of direct debit 
 WarningSomeDirectDebitOrdersAlreadyExists=Warning: There is already some pending Direct Debit orders (%s) requested for an amount of %s
 WarningSomeCreditTransferAlreadyExists=Warning: There is already some pending Credit Transfer (%s) requested for an amount of %s  
 UsedFor=Used for %s
+unprocessedRequest=unprocessed request,
+paymentsCoveringEntireInvoice=Payments covering the entire invoice have already been entered!
+requestedAmountExceedsOutstanding=the requested amount (%s) exceeds the outstanding amount (%s)

--- a/htdocs/langs/fr_FR/withdrawals.lang
+++ b/htdocs/langs/fr_FR/withdrawals.lang
@@ -32,6 +32,7 @@ InvoiceWaitingWithdraw=Factures en attente de prélèvement
 InvoiceWaitingPaymentByBankTransfer=Facture en attente de virement
 AmountToWithdraw=Somme à prélever
 AmountToTransfer=Montant du virement
+NoInvoiceSelected=Aucune facture sélectionnée
 NoInvoiceToWithdraw=Aucune facture ouverte pour '%s' n'est en attente. Allez sur l'onglet '%s' sur la facture pour faire une demande.
 NoSupplierInvoiceToWithdraw=Aucune facture fournisseur avec '%s' ouvert n'est en attente. Allez sur l'onglet '%s' sur la fiche de facturation pour faire une demande.
 ResponsibleUser=Utilisateur responsable

--- a/htdocs/langs/fr_FR/withdrawals.lang
+++ b/htdocs/langs/fr_FR/withdrawals.lang
@@ -161,3 +161,6 @@ TotalAmountOfdirectDebitOrderDiffersFromSumOfLines=Le montant total de l'ordre d
 WarningSomeDirectDebitOrdersAlreadyExists=Attention : Il y a déjà des ordres de prélèvement automatique en attente (%s) demandés pour un montant de %s
 WarningSomeCreditTransferAlreadyExists=Attention : Il y a déjà des virements en attente (%s) demandés pour un montant de %s
 UsedFor=Utilisé pour %s
+unprocessedRequest=demande non traité,
+paymentsCoveringEntireInvoice=des paiements couvrant la totalité de la facture sont dèjà saisie !
+requestedAmountExceedsOutstanding=le montant demandé (%s) dépasse le montant restant dû (%s)


### PR DESCRIPTION
Sur l'écran de virement bancaire:
- ajouter des champs pour filtrer les lignes à inclure dans le virement
- pouvoir sélectionner les lignes pour lesquelles on veut envoyer un ordre de virement.

Cette PR est en easya only pour le moment car un onglet "salaires" a été ajouté à cette page sur DLB develop, et la PR upstream est à adapter fortement.