### PR TITLE
CORE ODT: Support des balise [IF] autre par que le corps du document ODT, exemple les entêtes PR #29357

### DIFF
--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -549,10 +549,15 @@ IMG;
 	 */
 	private function _parse($type = 'content')
 	{
+		if ($type == 'content') $xml = &$this->contentXml;
+		elseif ($type == 'styles') $xml = &$this->stylesXml;
+		elseif ($type == 'meta') $xml = &$this->metaXml;
+		else return;
+
 		// Search all tags found into condition to complete $this->vars, so we will proceed all tests even if not defined
 		$reg='@\[!--\sIF\s([{}a-zA-Z0-9\.\,_]+)\s--\]@smU';
 		$matches = array();
-		preg_match_all($reg, $this->contentXml, $matches, PREG_SET_ORDER);
+		preg_match_all($reg, $xml, $matches, PREG_SET_ORDER);
 
 		//var_dump($this->vars);exit;
 		foreach ($matches as $match) {   // For each match, if there is no entry into this->vars, we add it
@@ -568,13 +573,13 @@ IMG;
 			// If value is true (not 0 nor false nor null nor empty string)
 			if ($value) {
 				//dol_syslog("Var ".$key." is defined, we remove the IF, ELSE and ENDIF ");
-				//$sav=$this->contentXml;
+				//$sav=$xml;
 				// Remove the IF tag
-				$this->contentXml = str_replace('[!-- IF '.$key.' --]', '', $this->contentXml);
+				$xml = str_replace('[!-- IF '.$key.' --]', '', $xml);
 				// Remove everything between the ELSE tag (if it exists) and the ENDIF tag
 				$reg = '@(\[!--\sELSE\s' . $key . '\s--\](.*))?\[!--\sENDIF\s' . $key . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
-				$this->contentXml = preg_replace($reg, '', $this->contentXml);
-				/*if ($sav != $this->contentXml)
+				$xml = preg_replace($reg, '', $xml);
+				/*if ($sav != $xml)
 				 {
 				 dol_syslog("We found a IF and it was processed");
 				 //var_dump($sav);exit;
@@ -583,16 +588,16 @@ IMG;
 				// Else the value is false, then two cases: no ELSE and we're done, or there is at least one place where there is an ELSE clause, then we replace it
 
 				//dol_syslog("Var ".$key." is not defined, we remove the IF, ELSE and ENDIF ");
-				//$sav=$this->contentXml;
+				//$sav=$xml;
 				// Find all conditional blocks for this variable: from IF to ELSE and to ENDIF
 				$reg = '@\[!--\sIF\s' . $key . '\s--\](.*)(\[!--\sELSE\s' . $key . '\s--\](.*))?\[!--\sENDIF\s' . $key . '\s--\]@smU'; // U modifier = all quantifiers are non-greedy
-				preg_match_all($reg, $this->contentXml, $matches, PREG_SET_ORDER);
+				preg_match_all($reg, $xml, $matches, PREG_SET_ORDER);
 				foreach ($matches as $match) { // For each match, if there is an ELSE clause, we replace the whole block by the value in the ELSE clause
-					if (!empty($match[3])) $this->contentXml = str_replace($match[0], $match[3], $this->contentXml);
+					if (!empty($match[3])) $xml = str_replace($match[0], $match[3], $xml);
 				}
 				// Cleanup the other conditional blocks (all the others where there were no ELSE clause, we can just remove them altogether)
-				$this->contentXml = preg_replace($reg, '', $this->contentXml);
-				/*if ($sav != $this->contentXml)
+				$xml = preg_replace($reg, '', $xml);
+				/*if ($sav != $xml)
 				 {
 				 dol_syslog("We found a IF and it was processed");
 				 //var_dump($sav);exit;
@@ -601,9 +606,7 @@ IMG;
 		}
 
 		// Static substitution
-		if ($type == 'content')	$this->contentXml = str_replace(array_keys($this->vars), array_values($this->vars), $this->contentXml);
-		if ($type == 'styles')	$this->stylesXml = str_replace(array_keys($this->vars), array_values($this->vars), $this->stylesXml);
-		if ($type == 'meta')	$this->metaXml = str_replace(array_keys($this->vars), array_values($this->vars), $this->metaXml);
+		$xml = str_replace(array_keys($this->vars), array_values($this->vars), $xml);
 	}
 
 	/**


### PR DESCRIPTION
Support des balise [IF] autre par que le corps du document ODT, exemple les entêtes PR #29357