### PR TITLE
TEMP FIX allow long formconfirms

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5389,7 +5389,7 @@ class Form
 
 			// BEGIN EASYA ONLY CHANGE
 			// $postconfirmas = 'GET'; // Added by Eldy with message "Fix regression using confirm as POST (pb with cursor and download file)". I do not encounter any problem but I need long formconfirms.
-			$postconfirmas = 'POST';
+			$postconfirmas = (getDolGlobalInt('EASYA_SEND_FORMCONFIRM_AS_POST') ? 'POST' : 'GET');
 			// END EASYA ONLY CHANGE
 
 			$formconfirm .= '

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5387,7 +5387,10 @@ class Form
 				$jsforcursor .= 'jQuery("html,body,#id-container").addClass("cursorwait");' . "\n";
 			}
 
-			$postconfirmas = 'GET';
+			// BEGIN EASYA ONLY CHANGE
+			// $postconfirmas = 'GET'; // Added by Eldy with message "Fix regression using confirm as POST (pb with cursor and download file)". I do not encounter any problem but I need long formconfirms.
+			$postconfirmas = 'POST';
+			// END EASYA ONLY CHANGE
 
 			$formconfirm .= '
                     resizable: false,


### PR DESCRIPTION
Easya Only.

Eldy a [bloqué l'envoi en POST](https://github.com/Dolibarr/dolibarr/commit/45c4a6ce1c2ec863c06d560bbd4963b4b73b08d4#r141214517) des formconfirms, pour cause de régression. Problème : 
- la régression n'est pas décrite précisément :-1: 
- je ne trouve pas comment la reproduire
- on a besoin des formconfirms longs

Je propose donc de passer cette PR en Easya Only.

Elle introduit une constante EASYA_SEND_FORMCONFIRM_AS_POST