### PR TITLE
FIX lettering (auto) for invoice deposit with company discount

### DIFF
--- a/htdocs/accountancy/class/lettering.class.php
+++ b/htdocs/accountancy/class/lettering.class.php
@@ -848,6 +848,7 @@ class Lettering extends BookKeeping
 				$sql .= "   LEFT JOIN " . MAIN_DB_PREFIX . $linked_info['table_link_line'] . " AS tll ON tll." . $linked_info['fk_table_link_line'] . " = tl." . $linked_info['fk_line_link'];
 				$sql .= ") AS tl2 ON tl2.fk_link = tl.fk_link";
 				$sql .= " WHERE tl.fk_doc IN (" . $this->db->sanitize(implode(',', $document_ids)) . ")";
+				$sql .= " AND tl2.fk_doc IS NOT NULL";
 			}
 
 			dol_syslog(__METHOD__ . " - Get document lines", LOG_DEBUG);

--- a/htdocs/accountancy/class/lettering.class.php
+++ b/htdocs/accountancy/class/lettering.class.php
@@ -51,6 +51,10 @@ class Lettering extends BookKeeping
 					'table' => 'societe_remise_except',
 					'fk_doc' => 'fk_facture_source',
 					'fk_link' => 'fk_facture',
+					'fk_line_link' => 'fk_facture_line',
+					'table_link_line' => 'facturedet',
+					'fk_table_link_line' => 'rowid',
+					'fk_table_link_line_parent' => 'fk_facture',
 					'prefix' => 'a',
 					'is_fk_link_is_also_fk_doc' => true,
 				),
@@ -73,6 +77,10 @@ class Lettering extends BookKeeping
 					'table' => 'societe_remise_except',
 					'fk_doc' => 'fk_invoice_supplier_source',
 					'fk_link' => 'fk_invoice_supplier',
+					'fk_line_link' => 'fk_invoice_supplier_line',
+					'table_link_line' => 'facture_fourn_det',
+					'fk_table_link_line' => 'rowid',
+					'fk_table_link_line_parent' => 'fk_facture_fourn',
 					'prefix' => 'a',
 					'is_fk_link_is_also_fk_doc' => true,
 				),
@@ -822,10 +830,25 @@ class Lettering extends BookKeeping
 		$link_by_element = array();
 		$element_by_link = array();
 		foreach ($doc_type_info['linked_info'] as $linked_info) {
-			$sql = "SELECT DISTINCT tl2." . $linked_info['fk_link'] . " AS fk_link, tl2." . $linked_info['fk_doc'] . " AS fk_doc";
-			$sql .= " FROM " . MAIN_DB_PREFIX . $linked_info['table'] . " AS tl";
-			$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . $linked_info['table'] . " AS tl2 ON tl2." . $linked_info['fk_link'] . " = tl." . $linked_info['fk_link'];
-			$sql .= " WHERE tl." . $linked_info['fk_doc'] . " IN (" . $this->db->sanitize(implode(',', $document_ids)) . ")";
+			if (empty($linked_info['fk_line_link'])) {
+				$sql = "SELECT DISTINCT tl2.".$linked_info['fk_link']." AS fk_link, tl2.".$linked_info['fk_doc']." AS fk_doc";
+				$sql .= " FROM ".MAIN_DB_PREFIX.$linked_info['table']." AS tl";
+				$sql .= " LEFT JOIN ".MAIN_DB_PREFIX.$linked_info['table']." AS tl2 ON tl2.".$linked_info['fk_link']." = tl.".$linked_info['fk_link'];
+				$sql .= " WHERE tl.".$linked_info['fk_doc']." IN (".$this->db->sanitize(implode(',', $document_ids)).")";
+			} else {
+				$sql = "SELECT DISTINCT tl2.fk_link, tl2.fk_doc";
+				$sql .= " FROM (";
+				$sql .= "   SELECT DISTINCT " . $this->db->ifsql("tll." . $linked_info['fk_table_link_line_parent'],  "tll." . $linked_info['fk_table_link_line_parent'],  "tl." . $linked_info['fk_link']) . " AS fk_link, tl." . $linked_info['fk_doc'] . " AS fk_doc";
+				$sql .= "   FROM " . MAIN_DB_PREFIX . $linked_info['table'] . " AS tl";
+				$sql .= "   LEFT JOIN " . MAIN_DB_PREFIX . $linked_info['table_link_line'] . " AS tll ON tll." . $linked_info['fk_table_link_line'] . " = tl." . $linked_info['fk_line_link'];
+				$sql .= ") AS tl";
+				$sql .= " LEFT JOIN (";
+				$sql .= "   SELECT DISTINCT " . $this->db->ifsql("tll." . $linked_info['fk_table_link_line_parent'],  "tll." . $linked_info['fk_table_link_line_parent'],  "tl." . $linked_info['fk_link']) . " AS fk_link, tl." . $linked_info['fk_doc'] . " AS fk_doc";
+				$sql .= "   FROM " . MAIN_DB_PREFIX . $linked_info['table'] . " AS tl";
+				$sql .= "   LEFT JOIN " . MAIN_DB_PREFIX . $linked_info['table_link_line'] . " AS tll ON tll." . $linked_info['fk_table_link_line'] . " = tl." . $linked_info['fk_line_link'];
+				$sql .= ") AS tl2 ON tl2.fk_link = tl.fk_link";
+				$sql .= " WHERE tl.fk_doc IN (" . $this->db->sanitize(implode(',', $document_ids)) . ")";
+			}
 
 			dol_syslog(__METHOD__ . " - Get document lines", LOG_DEBUG);
 			$resql = $this->db->query($sql);


### PR DESCRIPTION
FIX lettering (auto) for invoice deposit with company discount already used in another invoice

You got this invoice deposit : 
![image](https://github.com/Easya-Solutions/dolibarr/assets/45359511/286c9f64-c0b9-4648-84b1-e7c65fe6bd45)

And a discount was consumed on this invoice :
![image](https://github.com/Easya-Solutions/dolibarr/assets/45359511/b1662185-439c-4be8-b10c-356596324d3b)

When you want to letter (automatic) the invoice account : 
![image](https://github.com/Easya-Solutions/dolibarr/assets/45359511/5ccdbc56-5a56-4714-9312-0f9d9975c0a7)
- you got a SQL error :
- **Error You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ') AND dpn.piece_num = ab.piece_num )) AND ab.subledger_account != ''' at line 1**

**Before**
The linked documents of the invoice deposit was wrong. The SQL request searched for linked documents by "fk_facture" (customer) or "fk_invoice_supplier" (supplier) but not by "fk_facture_line" (customer) or "fk_invoice_supplier_line" (supplier).
And in some cases, the "fk_facture" was not set (NULL) and only the field "fk_facture_line" was set.

**After**
To fix it, the SQL request search for linked documents by "fk_facture" or "fk_facture_line" for customer invoices and search by "fk_invoice_supplier" or "fk_invoice_supplier_line" for supplier invoices.