### PR TITLE
NEW auto-determine piece number in FEC import

### DIFF
--- a/htdocs/accountancy/class/accountancyimport.class.php
+++ b/htdocs/accountancy/class/accountancyimport.class.php
@@ -100,13 +100,12 @@ class AccountancyImport
 		if (isset($listfields['b.debit']) && isset($listfields['b.credit'])) {
 			$debit_index = $listfields['b.debit'];
 
-			$debit  = price2num($arrayrecord[$debit_index]['val']);
-			$debitFloat = (float) $debit;
+			$debitFloat = (float) price2num($arrayrecord[$debit_index]['val']);
 			if (!empty($debitFloat)) {
-				$amount = $debit;
+				$amount = $debitFloat;
 			} else {
 				$credit_index = $listfields['b.credit'];
-				$amount = price2num($arrayrecord[$credit_index]['val']);
+				$amount = (float) price2num($arrayrecord[$credit_index]['val']);
 			}
 
 			return "'" . $this->db->escape(abs($amount)) . "'";
@@ -129,7 +128,7 @@ class AccountancyImport
 		if (isset($listfields['b.debit'])) {
 			$debit_index = $listfields['b.debit'];
 
-			$debitFloat = (float) (price2num($arrayrecord[$debit_index]['val']));
+			$debitFloat = (float) price2num($arrayrecord[$debit_index]['val']);
 			if (!empty($debitFloat)) {
 				$sens = 'D';
 			} else {

--- a/htdocs/accountancy/class/accountancyimport.class.php
+++ b/htdocs/accountancy/class/accountancyimport.class.php
@@ -44,6 +44,10 @@ class AccountancyImport
 	 */
 	public $db;
 
+	/**
+	 * @var string[]	Array of error strings
+	 */
+	public $errors = array();
 
 	/**
 	 * Constructor
@@ -61,12 +65,12 @@ class AccountancyImport
 	 * @param   array       $arrayrecord        Array of read values: [fieldpos] => (['val']=>val, ['type']=>-1=null,0=blank,1=string), [fieldpos+1]...
 	 * @param   array       $listfields         Fields list to add
 	 * @param 	int			$record_key         Record key
-	 * @return  mixed							Value
+	 * @return  float							Value
 	 */
 	public function cleanAmount(&$arrayrecord, $listfields, $record_key)
 	{
 		$value_trim = trim($arrayrecord[$record_key]['val']);
-		return floatval($value_trim);
+		return (float) price2num($value_trim);
 	}
 
 	/**
@@ -88,21 +92,21 @@ class AccountancyImport
 	 * @param   array       $arrayrecord        Array of read values: [fieldpos] => (['val']=>val, ['type']=>-1=null,0=blank,1=string), [fieldpos+1]...
 	 * @param   array       $listfields         Fields list to add
 	 * @param 	int			$record_key         Record key
-	 * @return  mixed							Value
+	 * @return  string							Value
 	 */
 	public function computeAmount(&$arrayrecord, $listfields, $record_key)
 	{
 		// get fields indexes
 		if (isset($listfields['b.debit']) && isset($listfields['b.credit'])) {
 			$debit_index = $listfields['b.debit'];
-			$credit_index = $listfields['b.credit'];
 
-			$debit  = floatval($arrayrecord[$debit_index]['val']);
-			$credit = floatval($arrayrecord[$credit_index]['val']);
-			if (!empty($debit)) {
+			$debit  = price2num($arrayrecord[$debit_index]['val']);
+			$debitFloat = (float) $debit;
+			if (!empty($debitFloat)) {
 				$amount = $debit;
 			} else {
-				$amount = $credit;
+				$credit_index = $listfields['b.credit'];
+				$amount = price2num($arrayrecord[$credit_index]['val']);
 			}
 
 			return "'" . $this->db->escape(abs($amount)) . "'";
@@ -118,15 +122,15 @@ class AccountancyImport
 	 * @param   array       $arrayrecord        Array of read values: [fieldpos] => (['val']=>val, ['type']=>-1=null,0=blank,1=string), [fieldpos+1]...
 	 * @param   array       $listfields         Fields list to add
 	 * @param 	int			$record_key         Record key
-	 * @return  mixed							Value
+	 * @return  string							Value
 	 */
 	public function computeDirection(&$arrayrecord, $listfields, $record_key)
 	{
 		if (isset($listfields['b.debit'])) {
 			$debit_index = $listfields['b.debit'];
 
-			$debit = floatval($arrayrecord[$debit_index]['val']);
-			if (!empty($debit)) {
+			$debitFloat = (float) (price2num($arrayrecord[$debit_index]['val']));
+			if (!empty($debitFloat)) {
 				$sens = 'D';
 			} else {
 				$sens = 'C';
@@ -136,5 +140,79 @@ class AccountancyImport
 		}
 
 		return "''";
+	}
+
+	/**
+	 *  Compute piece number
+	 *
+	 * @param   array       $arrayrecord        Array of read values: [fieldpos] => (['val']=>val, ['type']=>-1=null,0=blank,1=string), [fieldpos+1]...
+	 * @param   array       $listfields         Fields list to add
+	 * @param 	int			$record_key         Record key
+	 * @return  string							Value
+	 */
+	public function computePieceNum(&$arrayrecord, $listfields, $record_key)
+	{
+		global $conf;
+
+		$pieceNum = trim($arrayrecord[$record_key]['val']);
+
+		// auto-determine the next value for piece number
+		if ($pieceNum == '') {
+			if (isset($listfields['b.code_journal']) && isset($listfields['b.doc_date'])) {
+				// define memory for last record values and keep next piece number
+				if (!isset($conf->cache['accounting'])) {
+					$conf->cache['accounting'] = array(
+						'lastRecordCompareValues' => array(),
+						'nextPieceNum' => 0,
+					);
+				}
+				$codeJournalIndex = $listfields['b.code_journal'];
+				$docDateIndex = $listfields['b.doc_date'];
+				$atLeastOneLastRecordChanged = false;
+				if (empty($conf->cache['accounting']['lastRecordCompareValues'])) {
+					$atLeastOneLastRecordChanged = true;
+				} else {
+					if ($arrayrecord[$codeJournalIndex]['val'] != $conf->cache['accounting']['lastRecordCompareValues']['b.code_journal']
+						|| $arrayrecord[$docDateIndex]['val'] != $conf->cache['accounting']['lastRecordCompareValues']['b.doc_date']
+					) {
+						$atLeastOneLastRecordChanged = true;
+					}
+				}
+
+				// at least one record value has changed, so we search for the next piece number from database or increment it
+				if ($atLeastOneLastRecordChanged === true) {
+					$lastPieceNum = 0;
+					if (empty($conf->cache['accounting']['nextPieceNum'])) {
+						// get last piece number from database
+						$sql = "SELECT MAX(piece_num) as last_piece_num";
+						$sql .= " FROM ".$this->db->prefix()."accounting_bookkeeping";
+						$sql .= " WHERE entity IN (".getEntity('accountingbookkeeping').")";
+						$res = $this->db->query($sql);
+						if (!$res) {
+							$this->errors[] = $this->db->lasterror();
+							return '';
+						}
+						if ($obj = $this->db->fetch_object($res)) {
+							$lastPieceNum = (int) $obj->last_piece_num;
+						}
+						$this->db->free($res);
+					}
+					// set next piece number in memory
+					if (empty($conf->cache['accounting']['nextPieceNum'])) {
+						$conf->cache['accounting']['nextPieceNum'] = $lastPieceNum;
+					}
+					$conf->cache['accounting']['nextPieceNum']++;
+
+					// set last records values in memory
+					$conf->cache['accounting']['lastRecordCompareValues'] = array(
+						'b.code_journal' => $arrayrecord[$codeJournalIndex]['val'],
+						'b.doc_date' => $arrayrecord[$docDateIndex]['val'],
+					);
+				}
+				$pieceNum = (string) $conf->cache['accounting']['nextPieceNum'];
+			}
+		}
+
+		return $pieceNum;
 	}
 }

--- a/htdocs/core/modules/modAccounting.class.php
+++ b/htdocs/core/modules/modAccounting.class.php
@@ -336,7 +336,7 @@ class modAccounting extends DolibarrModules
 		$this->import_fields_array[$r] = array(
 			'b.code_journal'=>'FECFormatJournalCode*',
 			'b.journal_label'=>'FECFormatJournalLabel',
-			'b.piece_num'=>'FECFormatEntryNum*',
+			'b.piece_num'=>'FECFormatEntryNum', // not mandatory (keep empty to get next value of "piece_num" from "llx_accounting_bookkeeping table")
 			'b.doc_date'=>'FECFormatEntryDate*',
 			'b.numero_compte'=>'FECFormatGeneralAccountNumber*',
 			'b.label_compte'=>'FECFormatGeneralAccountLabel*',
@@ -362,7 +362,7 @@ class modAccounting extends DolibarrModules
 			'b.sens'=>'rule-computeDirection'
 		); // aliastable.field => ('user->id' or 'lastrowid-'.tableparent)
 		$this->import_convertvalue_array[$r]=array(
-			'b.piece_num' => array('rule' => 'compute', 'classfile' => '/accountancy/class/accountancyimport.class.php', 'class' => 'AccountancyImport', 'method' => 'cleanValue', 'element' => 'Accountancy'),
+			'b.piece_num' => array('rule' => 'compute', 'classfile' => '/accountancy/class/accountancyimport.class.php', 'class' => 'AccountancyImport', 'method' => 'computePieceNum', 'element' => 'Accountancy'),
 			'b.numero_compte'=>array('rule'=>'accountingaccount'),
 			'b.subledger_account'=>array('rule'=>'accountingaccount'),
 			'b.debit' => array('rule' => 'compute', 'classfile' => '/accountancy/class/accountancyimport.class.php', 'class' => 'AccountancyImport', 'method' => 'cleanAmount', 'element' => 'Accountancy'),

--- a/htdocs/core/modules/modAccounting.class.php
+++ b/htdocs/core/modules/modAccounting.class.php
@@ -336,7 +336,7 @@ class modAccounting extends DolibarrModules
 		$this->import_fields_array[$r] = array(
 			'b.code_journal'=>'FECFormatJournalCode*',
 			'b.journal_label'=>'FECFormatJournalLabel',
-			'b.piece_num'=>'FECFormatEntryNum', // not mandatory (keep empty to get next value of "piece_num" from "llx_accounting_bookkeeping table")
+			'b.piece_num'=>'FECFormatEntryNum', // not mandatory (keep empty to get next value of "piece_num" from "llx_accounting_bookkeeping" table)
 			'b.doc_date'=>'FECFormatEntryDate*',
 			'b.numero_compte'=>'FECFormatGeneralAccountNumber*',
 			'b.label_compte'=>'FECFormatGeneralAccountLabel*',


### PR DESCRIPTION
NEW auto-determine piece number in FEC import
- DLB : #29672
- here the amounts in import file can have a point "." or a comma "," as separtor of decimals

The field of piece number is now not mandatory in FEC import :
- auto-determine piece number if empty in import file (column "EcritureNum") with the next value of "piecenum" in "accounting_bookkeeping" table 
- then the next value for piece number is incremented when the column "JournalCode" or "EcritureDate" of import file has changed