### PR TITLE
Fix of an incorrect translation code and added a missing one

### DIFF
--- a/htdocs/contrat/services_list.php
+++ b/htdocs/contrat/services_list.php
@@ -482,10 +482,10 @@ if ($search_status == "4") {
 	$title = $langs->trans("ListOfRunningServices");
 }
 if ($search_status == "4&filter=notexpired") {
-	$title = $langs->trans("ListOfNotExpiredRunningServices");
+	$title = $langs->trans("ListOfNotExpiredServices");
 }
 if ($search_status == "4&filter=expired") {
-	$title = $langs->trans("ListOfExpiredRunningServices");
+	$title = $langs->trans("ListOfExpiredServices");
 }
 if ($search_status == "5") {
 	$title = $langs->trans("ListOfClosedServices");

--- a/htdocs/langs/fr_FR/contracts.lang
+++ b/htdocs/langs/fr_FR/contracts.lang
@@ -47,6 +47,7 @@ DateContract=Date contrat
 DateServiceActivate=Date activation du service
 ListOfServices=Liste des services
 ListOfInactiveServices=Liste des services inactifs
+ListOfNotExpiredServices=Liste des services actifs non expirés
 ListOfExpiredServices=Liste des services actifs expirés
 ListOfClosedServices=Liste des services fermés
 ListOfRunningServices=Liste des services actifs


### PR DESCRIPTION
# Fix #[*#29804*]
The translation code was incorrect and corresponded to nothing inside the language files and one of the translation was missing