### PR TITLE
FIX group by qty in product margin tab

### DIFF
--- a/htdocs/margin/tabs/productMargins.php
+++ b/htdocs/margin/tabs/productMargins.php
@@ -161,7 +161,7 @@ if ($id > 0 || !empty($ref)) {
 				$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 			}
 			if (!empty($socid)) {
-				$sql .= " AND f.fk_soc = $socid";
+				$sql .= " AND f.fk_soc = ".((int) $socid);
 			}
 			$sql .= " AND d.buy_price_ht IS NOT NULL";
 			// We should not use this here. Option ForceBuyingPriceIfNull should have effect only when inserting data. Once data is recorded, it must be used as it is for report.
@@ -195,7 +195,7 @@ if ($id > 0 || !empty($ref)) {
 				print_liste_field_titre("DateInvoice", $_SERVER["PHP_SELF"], "f.datef", "", "&amp;id=".$object->id, '', $sortfield, $sortorder, 'left ');
 				print_liste_field_titre("SellingPrice", $_SERVER["PHP_SELF"], "selling_price", "", "&amp;id=".$object->id, '', $sortfield, $sortorder, 'right ');
 				print_liste_field_titre("BuyingPrice", $_SERVER["PHP_SELF"], "buying_price", "", "&amp;id=".$object->id, '', $sortfield, $sortorder, 'right ');
-				print_liste_field_titre("Qty", $_SERVER["PHP_SELF"], "d.qty", "", "&amp;id=".$object->id, '', $sortfield, $sortorder, 'right ');
+				print_liste_field_titre("Qty", $_SERVER["PHP_SELF"], "qty", "", "&amp;id=".$object->id, '', $sortfield, $sortorder, 'right ');
 				print_liste_field_titre("Margin", $_SERVER["PHP_SELF"], "marge", "", "&amp;id=".$object->id, '', $sortfield, $sortorder, 'right ');
 				if (!empty($conf->global->DISPLAY_MARGIN_RATES)) {
 					print_liste_field_titre("MarginRate", $_SERVER["PHP_SELF"], "", "", "&amp;id=".$object->id, '', $sortfield, $sortorder, 'right ');


### PR DESCRIPTION
FIX group by qty in product margin tab
DLB : #29853

You got an SQL error when you want to order by "Qty" in product margin tab :
SQL error : 
_ORDER BY clause is not in GROUP BY clause and contains nonaggregated column 'd.qty' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by_