### PR TITLE
fix: In Supplier Invoice, tab Attachments, the link to the file is wrong

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1296,11 +1296,18 @@ class FormFile
 						$lastrowid = $filearray[$key]['rowid'];
 					}
 					$filepath = $file['level1name'].'/'.$file['name'];
-					$modulepart = basename(dirname($file['path']));
-					$relativepath = preg_replace('/\/(.+)/', '', $filepath) . '/';
+					if ($modulepart!=='facture_fournisseur') {
+						$filepath = $file['level1name'].'/'.$file['name'];
+						$modulepart = basename(dirname($file['path']));
+						$relativepath = preg_replace('/\/(.+)/', '', $filepath) . '/';
+					} else {
+						$filepath = $relativepath.$file['name'];
+					}
+
 
 					$editline = 0;
 					$nboflines++;
+
 					print '<!-- Line list_of_documents '.$key.' relativepath = '.$relativepath.' -->'."\n";
 					// Do we have entry into database ?
 					print '<!-- In database: position='.$filearray[$key]['position'].' -->'."\n";
@@ -1308,7 +1315,6 @@ class FormFile
 
 					// File name
 					print '<td class="minwith200">';
-
 					// Preview link
 					if (!$editline) {
 						print $this->showPreview($file, $modulepart, $filepath, 0, '&entity='.(!empty($object->entity) ? $object->entity : $conf->entity), 'paddingright') . "\n";

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1295,14 +1295,7 @@ class FormFile
 					if ($filearray[$key]['rowid'] > 0) {
 						$lastrowid = $filearray[$key]['rowid'];
 					}
-					if ($modulepart!=='facture_fournisseur') {
-						$filepath = $file['level1name'].'/'.$file['name'];
-						$modulepart = basename(dirname($file['path']));
-						$relativepath = preg_replace('/\/(.+)/', '', $filepath) . '/';
-					} else {
-						$filepath = $relativepath.$file['name'];
-					}
-
+					$filepath = $relativepath.$file['name'];
 
 					$editline = 0;
 					$nboflines++;

--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1295,7 +1295,6 @@ class FormFile
 					if ($filearray[$key]['rowid'] > 0) {
 						$lastrowid = $filearray[$key]['rowid'];
 					}
-					$filepath = $file['level1name'].'/'.$file['name'];
 					if ($modulepart!=='facture_fournisseur') {
 						$filepath = $file['level1name'].'/'.$file['name'];
 						$modulepart = basename(dirname($file['path']));


### PR DESCRIPTION
Don't know why this commit
https://github.com/Easya-Solutions/dolibarr/blame/4880cb2afc18084dbf0a4d0d3db23954609473c1/htdocs/core/class/html.formfile.class.php#L1298

In version 14 or in newest version there is no code to rewrite modulepart/path of the file base on directory structure. I imagine it was for Easya needs

Result it work in most of the case because document/"modulepart"/"ref"/"file.ext" is true most of the time but not for supplier invoice where the document is save with document/facturefourn/"number"/"number"/"file.ext"