### PR TITLE
FIX init total amounts in margin module

### DIFF
--- a/htdocs/margin/agentMargins.php
+++ b/htdocs/margin/agentMargins.php
@@ -226,7 +226,9 @@ if (!empty($enddateyear)) {
 	$param .= "&amp;enddateyear=".urlencode($enddateyear);
 }
 
-
+$totalMargin = 0;
+$marginRate = '';
+$markRate = '';
 dol_syslog('margin::agentMargins.php', LOG_DEBUG);
 $result = $db->query($sql);
 if ($result) {

--- a/htdocs/margin/customerMargins.php
+++ b/htdocs/margin/customerMargins.php
@@ -297,6 +297,9 @@ if (is_array($listofcateg)) {
 	}
 }
 
+$totalMargin = 0;
+$marginRate = '';
+$markRate = '';
 dol_syslog('margin::customerMargins.php', LOG_DEBUG);
 $result = $db->query($sql);
 if ($result) {

--- a/htdocs/margin/productMargins.php
+++ b/htdocs/margin/productMargins.php
@@ -247,6 +247,9 @@ if (is_array($listofcateg)) {
 	}
 }
 
+$totalMargin = 0;
+$marginRate = '';
+$markRate = '';
 dol_syslog('margin::productMargins.php', LOG_DEBUG);
 $result = $db->query($sql);
 if ($result) {

--- a/htdocs/margin/tabs/productMargins.php
+++ b/htdocs/margin/tabs/productMargins.php
@@ -75,8 +75,8 @@ $invoicestatic = new Facture($db);
 
 $form = new Form($db);
 $totalMargin = 0;
-$marginRate = 0;
-$markRate = 0;
+$marginRate = '';
+$markRate = '';
 if ($id > 0 || !empty($ref)) {
 	$result = $object->fetch($id, $ref);
 

--- a/htdocs/margin/tabs/thirdpartyMargins.php
+++ b/htdocs/margin/tabs/thirdpartyMargins.php
@@ -93,6 +93,9 @@ if (!empty($conf->global->MAIN_HTML_TITLE) && preg_match('/thirdpartynameonly/',
 $help_url = 'EN:Module_Third_Parties|FR:Module_Tiers|ES:Empresas';
 llxHeader('', $title, $help_url);
 
+$totalMargin = 0;
+$marginRate = '';
+$markRate = '';
 if ($socid > 0) {
 	$object = new Societe($db);
 	$object->fetch($socid);


### PR DESCRIPTION
FIX init total amounts in margin module
DLB : #29854

Init variables :
- totalMargin
- marginRate
- markRate

- marginRate and markRate are initialized with empty string : '' (it's used to show "n/a" in margin rate and mark rate)
