### PR TITLE
FIX show generated accountancy reports in user timezone

### DIFF
--- a/htdocs/core/lib/report.lib.php
+++ b/htdocs/core/lib/report.lib.php
@@ -118,7 +118,7 @@ function report_header($reportname, $notused, $period, $periodlink, $description
 	print '<tr>';
 	print '<td>'.$langs->trans("GeneratedOn").'</td>';
 	print '<td>';
-	print dol_print_date($builddate, 'dayhour');
+	print dol_print_date($builddate, 'dayhour', 'tzuserrel');
 	print '</td>';
 	if ($variante) {
 		print '<td>'.($exportlink ? $langs->trans("Export").': '.$exportlink : '').'</td>';


### PR DESCRIPTION
FIX show generated accountancy reports in user timezone
DLB : #29857

In all accountancy reports, the generated date is in server timezone.
And if user has a different timezone the generated date as few hours difference.
For example without this fix the user see "06/06/2024 13:10" instead of "06/06/2024 15:10" (now) in Generated date field.

![image](https://github.com/Dolibarr/dolibarr/assets/45359511/83f96867-1ee1-40d9-bf62-cb73bbe28c6a)