### PR TITLE
FIX : update date_lim_reglement when we update the invoice date in the past

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -412,7 +412,6 @@ if (empty($reshook)) {
 		$result = $object->setMulticurrencyRate(price2num(GETPOST('multicurrency_tx')), GETPOST('calculation_mode', 'int'));
 	} elseif ($action == 'setinvoicedate' && $usercancreate) {
 		$object->fetch($id);
-		$old_date_lim_reglement = $object->date_lim_reglement;
 		$newdate = dol_mktime(0, 0, 0, GETPOST('invoicedatemonth', 'int'), GETPOST('invoicedateday', 'int'), GETPOST('invoicedateyear', 'int'), 'tzserver');
 		if (empty($newdate)) {
 			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("Date")), null, 'errors');
@@ -428,10 +427,7 @@ if (empty($reshook)) {
 		}
 
 		$object->date = $newdate;
-		$new_date_lim_reglement = $object->calculate_date_lim_reglement();
-		if ($new_date_lim_reglement > $old_date_lim_reglement) {
-			$object->date_lim_reglement = $new_date_lim_reglement;
-		}
+		$object->date_lim_reglement = $object->calculate_date_lim_reglement();
 		if ($object->date_lim_reglement < $object->date) {
 			$object->date_lim_reglement = $object->date;
 		}

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -427,7 +427,10 @@ if (empty($reshook)) {
 		}
 
 		$object->date = $newdate;
-		$object->date_lim_reglement = $object->calculate_date_lim_reglement();
+		$new_date_lim_reglement = $object->calculate_date_lim_reglement();
+		if ($new_date_lim_reglement) {
+			$object->date_lim_reglement = $new_date_lim_reglement;
+		}
 		if ($object->date_lim_reglement < $object->date) {
 			$object->date_lim_reglement = $object->date;
 		}
@@ -465,7 +468,7 @@ if (empty($reshook)) {
 		if (!$error) {
 			$old_date_lim_reglement = $object->date_lim_reglement;
 			$new_date_lim_reglement = $object->calculate_date_lim_reglement();
-			if ($new_date_lim_reglement > $old_date_lim_reglement) {
+			if ($new_date_lim_reglement) {
 				$object->date_lim_reglement = $new_date_lim_reglement;
 			}
 			if ($object->date_lim_reglement < $object->date) {

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -360,9 +360,8 @@ if (empty($reshook)) {
 		}
 
 		if (!$error) {
-			$old_date_echeance = $object->date_echeance;
 			$new_date_echeance = $object->calculate_date_lim_reglement();
-			if ($new_date_echeance > $old_date_echeance) {
+			if ($new_date_echeance) {
 				$object->date_echeance = $new_date_echeance;
 			}
 			if ($object->date_echeance < $object->date) {
@@ -426,7 +425,7 @@ if (empty($reshook)) {
 
 		$object->date = $newdate;
 		$date_echence_calc = $object->calculate_date_lim_reglement();
-		if (!empty($object->date_echeance) && $object->date_echeance < $date_echence_calc) {
+		if (!empty($object->date_echeance)) {
 			$object->date_echeance = $date_echence_calc;
 		}
 		if ($object->date_echeance && $object->date_echeance < $object->date) {


### PR DESCRIPTION
Fix: date_lim_reglement of invoices is not updated when we update the invoice date in the past.
For customer and supplier invoices.
#29886