### PR TITLE
FIX rounding update price for expense report lines

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3603,7 +3603,11 @@ abstract class CommonObject
 				$total_ttc_by_vats[$obj->vatrate] += $obj->total_ttc;
 
 				if ($forcedroundingmode == '1') {	// Check if we need adjustement onto line for vat. TODO This works on the company currency but not on multicurrency
-					$tmpvat = price2num($total_ht_by_vats[$obj->vatrate] * $obj->vatrate / 100, 'MT', 1);
+					if ($base_price_type == 'TTC') {
+						$tmpvat = price2num($total_ttc_by_vats[$obj->vatrate] * $obj->vatrate / (100 + $obj->vatrate), 'MT', 1);
+					} else {
+						$tmpvat = price2num($total_ht_by_vats[$obj->vatrate] * $obj->vatrate / 100, 'MT', 1);
+					}
 					$diff = price2num($total_tva_by_vats[$obj->vatrate] - $tmpvat, 'MT', 1);
 					//print 'Line '.$i.' rowid='.$obj->rowid.' vat_rate='.$obj->vatrate.' total_ht='.$obj->total_ht.' total_tva='.$obj->total_tva.' total_ttc='.$obj->total_ttc.' total_ht_by_vats='.$total_ht_by_vats[$obj->vatrate].' total_tva_by_vats='.$total_tva_by_vats[$obj->vatrate].' (new calculation = '.$tmpvat.') total_ttc_by_vats='.$total_ttc_by_vats[$obj->vatrate].($diff?" => DIFF":"")."<br>\n";
 					if ($diff) {
@@ -3613,8 +3617,13 @@ abstract class CommonObject
 							dol_print_error('', $errmsg);
 							exit;
 						}
-						$sqlfix = "UPDATE ".MAIN_DB_PREFIX.$this->table_element_line." SET ".$fieldtva." = ".($obj->total_tva - $diff).", total_ttc = ".($obj->total_ttc - $diff)." WHERE rowid = ".$obj->rowid;
-						dol_syslog('We found a difference of '.$diff.' for line rowid = '.$obj->rowid.". We fix the total_vat and total_ttc of line by running sqlfix = ".$sqlfix);
+						if ($base_price_type == 'TTC') {
+							$sqlfix = "UPDATE ".$this->db->prefix().$this->table_element_line." SET ".$fieldtva." = ".price2num($obj->total_tva - (float) $diff).", total_ht = ".price2num($obj->total_ht + (float) $diff)." WHERE rowid = ".((int) $obj->rowid);
+							dol_syslog('We found a difference of '.$diff.' for line rowid = '.$obj->rowid.". We fix the total_vat and total_ht of line by running sqlfix = ".$sqlfix);
+						} else {
+							$sqlfix = "UPDATE ".MAIN_DB_PREFIX.$this->table_element_line." SET ".$fieldtva." = ".($obj->total_tva - $diff).", total_ttc = ".($obj->total_ttc - $diff)." WHERE rowid = ".$obj->rowid;
+							dol_syslog('We found a difference of '.$diff.' for line rowid = '.$obj->rowid.". We fix the total_vat and total_ttc of line by running sqlfix = ".$sqlfix);
+						}
 
 						$resqlfix = $this->db->query($sqlfix);
 
@@ -3623,9 +3632,14 @@ abstract class CommonObject
 						}
 
 						$this->total_tva = (float) price2num($this->total_tva - $diff, '', 1);
-						$this->total_ttc = (float) price2num($this->total_ttc - $diff, '', 1);
 						$total_tva_by_vats[$obj->vatrate] = (float) price2num($total_tva_by_vats[$obj->vatrate] - $diff, '', 1);
-						$total_ttc_by_vats[$obj->vatrate] = (float) price2num($total_ttc_by_vats[$obj->vatrate] - $diff, '', 1);
+						if ($base_price_type == 'TTC') {
+							$this->total_ht = (float) price2num($this->total_ht + (float) $diff, '', 1);
+							$total_ht_by_vats[$obj->vatrate] = (float) price2num($total_ht_by_vats[$obj->vatrate] + (float) $diff, '', 1);
+						} else {
+							$this->total_ttc = (float) price2num($this->total_ttc - $diff, '', 1);
+							$total_ttc_by_vats[$obj->vatrate] = (float) price2num($total_ttc_by_vats[$obj->vatrate] - $diff, '', 1);
+						}
 					}
 				}
 


### PR DESCRIPTION
FIX rounding update price for expense report lines
- when you set "MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND" const to 1 and when there is a difference between two methods to compute "Total VAT", in some cases total amount (TTC) is different of unit price amount  (TTC) even if quantity is set to 1.

In expense report, if you add a new line of an existing line with "MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND" set to 1 : 
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/f56ec569-0a1e-413f-889b-299068d656cc)
You got a non coherent "total amount" (TTC) : 6,21 instead of 6,20.
Here the quantity is 1, so the total amount should be the same as unit price value (TTC)

**Before**
What you got before the fix :
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/f08f24c2-7fb5-4140-9f48-285108bb9c48)

**After**
What you get after the fix :
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/14bb9b20-e601-4719-b3e2-0c36e764a3de)
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/12ec8b2c-7ae7-455a-afb0-a802d5df25a1)
You remark you get "5,17" in HT amount for line 1 and "5,16" in HT amount for line 2 but it's a correction value to have the HT total amount to "10,33" (in this case it's better to set quantity to 2)

And an other example with a positive diff between vat amounts :
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/5d4a5908-ab0c-4465-ace7-5bf6bd407bc1)
![image](https://github.com/Dolibarr/dolibarr/assets/45359511/6d8fc43f-dc9d-4b6f-a3f7-4a046b325cbb)
