### PR TITLE
Fix line_order when we have children with children + Backport

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3077,7 +3077,7 @@ abstract class CommonObject
 				while ($i < $num) {
 					$row = $this->db->fetch_row($resql);
 					$rows[] = $row[0]; // Add parent line into array rows
-					$childrens = $this->getChildrenOfLine($row[0]);
+					$childrens = $this->getChildrenOfLine($row[0], 1);
 					if (!empty($childrens)) {
 						foreach ($childrens as $child) {
 							array_push($rows, $child);
@@ -3127,7 +3127,7 @@ abstract class CommonObject
 				while ($row = $this->db->fetch_row($resql)) {
 					$rows[] = $row[0];
 					if (!empty($includealltree)) {
-						$rows = array_merge($rows, $this->getChildrenOfLine($row[0]), $includealltree);
+						$rows = array_merge($rows, $this->getChildrenOfLine($row[0], $includealltree));
 					}
 				}
 			}


### PR DESCRIPTION
# Fix [*#30421*] [*#30423*]

Fix case when we have children with children that are not taken into account and cause a problem with the rank of the lines
Backport of a fix on develop for the function getChildrenOfLine not working with $includealltree set