### PR TITLE
Fixes loss of rich text wrapping for translated category descriptions

### DIFF
--- a/htdocs/categories/traduction.php
+++ b/htdocs/categories/traduction.php
@@ -131,7 +131,7 @@ $cancel != $langs->trans("Cancel") &&
 
 	foreach ($object->multilangs as $key => $value) {     // recording of new values in the object
 		$libelle = GETPOST('libelle-'.$key, 'alpha');
-		$desc = GETPOST('desc-'.$key);
+		$desc = GETPOST('desc-'.$key, 'restricthtml');
 
 		if (empty($libelle)) {
 			$error++;


### PR DESCRIPTION
#30433
If multi-language is enabled, saving translations of category descriptions loses the rich text wrapping (wysiwyg)