### PR TITLE
Fix never used resprint

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -218,7 +218,7 @@ class MouvementStock extends CommonObject
 				}
 				return $reshook;
 			} elseif ($reshook > 0) {
-				return $hookmanager->resPrint;
+				return $reshook;
 			}
 		}
 		// end hook at beginning


### PR DESCRIPTION
# Fix #[*#30471*]
Fix a return from a function where the string return is never used and solving a case of error happening when reshook return 1 with a resprint empty. Since PHP8 an empty string is inferior to 0 which cause false error happening.