### PR TITLE
FIX fatal error on loading pictures in attached documents of an event

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -810,7 +810,7 @@ class ActionComm extends CommonObject
 				$this->type       = $obj->type_type;
 				/*$transcode = $langs->trans("Action".$obj->type_code);
 				$this->type       = (($transcode != "Action".$obj->type_code) ? $transcode : $obj->type_label); */
-				$transcode = $langs->trans("Action".$obj->type_code.'Short');
+				$transcode = (isset($langs) ? $langs->trans("Action".$obj->type_code.'Short') : '');
 				$this->type_short = (($transcode != "Action".$obj->type_code.'Short') ? $transcode : '');
 
 				$this->code = $obj->code;


### PR DESCRIPTION
FIX fatal error on loading pictures in attached documents of an event
- see https://github.com/Easya-Solutions/dolibarr/pull/1015
- but transcode is used here and it's a new way to fix it