### PR TITLE
NEW option: assign default roles to "individual" third-party contacts…

### DIFF
--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -2408,3 +2408,4 @@ AtBottomOfPage=At bottom of page
 FailedAuth=failed authentications
 MaxNumberOfFailedAuth=Max number of failed authentication in 24h to deny login.
 SpecialCharActivation=Enable the button to open a virtual keyboard to enter special characters
+ContactsDefaultRoles=For third parties of the "individual" type, a contact can be created simultaneously. Define here the roles that will be systematically assigned to this contact.

--- a/htdocs/langs/fr_FR/admin.lang
+++ b/htdocs/langs/fr_FR/admin.lang
@@ -2407,3 +2407,4 @@ AtBottomOfPage=En bas de page
 FailedAuth=échecs d'authentification
 MaxNumberOfFailedAuth=Max number of failed authentication in 24h to deny login.
 SpecialCharActivation=Activez le bouton pour ouvrir un clavier virtuel pour saisir des caractères spéciaux
+ContactsDefaultRoles=Pour les les tiers de type "particulier" un contact peut-être créé simultanément. Définissez ici les rôles qui seront systématiquement attribués à ce contact.

--- a/htdocs/societe/admin/societe.php
+++ b/htdocs/societe/admin/societe.php
@@ -29,6 +29,7 @@
 require '../../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formcompany.class.php';
 
 $langs->loadLangs(array("admin", "companies", "other"));
@@ -95,6 +96,18 @@ if ($action == 'updateoptions') {
 	if (GETPOST('THIRDPARTY_CUSTOMERTYPE_BY_DEFAULT')) {
 		$customertypedefault = GETPOST('defaultcustomertype', 'int');
 		$res = dolibarr_set_const($db, "THIRDPARTY_CUSTOMERTYPE_BY_DEFAULT", $customertypedefault, 'chaine', 0, '', $conf->entity);
+		if (!($res > 0)) {
+			$error++;
+		}
+		if (!$error) {
+			setEventMessages($langs->trans("SetupSaved"), null, 'mesgs');
+		} else {
+			setEventMessages($langs->trans("Error"), null, 'errors');
+		}
+	}
+	if (GETPOST('CONTACTS_DEFAULT_ROLES')) {
+		$rolessearch = GETPOST('activate_CONTACTS_DEFAULT_ROLES', 'array');
+		$res = dolibarr_set_const($db, "CONTACTS_DEFAULT_ROLES", implode(',', $rolessearch), 'chaine', 0, '', $conf->entity);
 		if (!($res > 0)) {
 			$error++;
 		}
@@ -916,7 +929,25 @@ if (empty($conf->global->SOCIETE_DISABLE_PROSPECTSCUSTOMERS)) {
 	print '</td>';
 	print '</tr>';
 }
-
+if (getDolGlobalString('THIRDPARTY_SUGGEST_ALSO_ADDRESS_CREATION')) {
+	print '<tr class="oddeven">';
+	print '<td width="80%">'.$langs->trans('ContactsDefaultRoles').'</td>';
+	if (!$conf->use_javascript_ajax) {
+		print '<td class="nowrap right" colspan="2">';
+		print $langs->trans("NotAvailableWhenAjaxDisabled");
+		print "</td>";
+	} else {
+		print '<td width="60" class="right">';
+		$contact = new Contact($db);
+		$contactType = $contact->listeTypeContacts('external', '', 1);
+		$selected = explode(',', getDolGlobalString('CONTACTS_DEFAULT_ROLES'));
+		print $form->multiselectarray('activate_CONTACTS_DEFAULT_ROLES', $contactType, $selected, 0, 0, 'minwidth75imp');
+		print '</td><td class="right">';
+		print '<input type="submit" class="button small eposition" name="CONTACTS_DEFAULT_ROLES" value="'.$langs->trans("Modify").'">';
+		print "</td>";
+	}
+	print '</tr>';
+}
 print '</table>';
 print '</div>';
 

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -1095,6 +1095,7 @@ class Societe extends CommonObject
 		$contact->town              = $this->town;
 		$this->setUpperOrLowerCase();
 		$contact->phone_pro         = $this->phone;
+		$contact->roles				= explode(',', getDolGlobalString('CONTACTS_DEFAULT_ROLES'));
 
 		$contactId = $contact->create($user, $notrigger);
 		if ($contactId < 0) {


### PR DESCRIPTION
#30499

When the option to automatically create a contact for third parties of the "Individuals" type is active (THIRDPARTY_SUGGEST_ALSO_ADDRESS_CREATION).

Allow to define the default roles assigned to these contacts.

Process:

1. Selection of default roles in the settings (and saving)
2. Creation of a third party of the "Individuals" type and therefore of its associated contact.
3. The contact thus created is automatically assigned the predefined roles.
