### PR TITLE
Fix error due to missmatch type for duration value

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -2617,7 +2617,7 @@ class Product extends CommonObject
 				$this->fk_default_bom = $obj->fk_default_bom;
 
 				$this->duration = $obj->duration;
-				$this->duration_value = $obj->duration ? substr($obj->duration, 0, dol_strlen($obj->duration) - 1) : null;
+				$this->duration_value = $obj->duration ? (int) (substr($obj->duration, 0, dol_strlen($obj->duration) - 1)) : 0;
 				$this->duration_unit = $obj->duration ? substr($obj->duration, -1) : null;
 				$this->canvas = $obj->canvas;
 				$this->net_measure = $obj->net_measure;


### PR DESCRIPTION
# Fix #[*#30593*]

Fix error due to mismatch type for duration value. It should be an INT as it is everywhere in the code compared to INT value and passed as an INT to function or used in INT operation.
Keeping as a string can cause in example this error `error evaluating code: Unsupported operand types: int + string`
since PHP8.0.