### PR TITLE
FIX attachment sent by mail from back office of ticket

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1753,7 +1753,7 @@ class Ticket extends CommonObject
 					if (dol_mkdir($destdir) >= 0) {
 						require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 						dol_move($filespath, $destfile);
-						if ($actioncomm->code == "TICKET_MSG") {
+						if (in_array($actioncomm->code,  array('TICKET_MSG', 'TICKET_MSG_SENTBYMAIL'))) {
 							$ecmfile = new EcmFiles($this->db);
 							$destdir = preg_replace('/^'.preg_quote(DOL_DATA_ROOT, '/').'/', '', $destdir);
 							$destdir = preg_replace('/[\\/]$/', '', $destdir);


### PR DESCRIPTION
FIX attachment sent by mail from back office of ticket (not share on public interface)
DLB : #30583

**To reproduce**
1. create a message with an attachment on ticket card (back office)
2. go to the public interface and you don't see the link for the attached file

**The fix**
- the code "TICKET_MSG_SENTBYMAIL" was not in the condition to create the "ECM" file in database with the share file hash
- the "hash" of the file is useful to show the attachment file from the public interface of ticket