### PR TITLE
Qual - Optimize requests in sells journal for situation invoices

### DIFF
--- a/htdocs/accountancy/journal/sellsjournal.php
+++ b/htdocs/accountancy/journal/sellsjournal.php
@@ -219,7 +219,7 @@ if ($result) {
 			$vatdata = $vatdata_cache[$tax_id];
 		} else {
 			$vatdata = getTaxesFromId($tax_id, $mysoc, $mysoc, 0);
-				$vatdata_cache[$tax_id] = $vatdata;
+			$vatdata_cache[$tax_id] = $vatdata;
 		}
 		$compta_tva = (!empty($vatdata['accountancy_code_sell']) ? $vatdata['accountancy_code_sell'] : $cpttva);
 		$compta_localtax1 = (!empty($vatdata['accountancy_code_sell']) ? $vatdata['accountancy_code_sell'] : $cpttva);
@@ -242,8 +242,7 @@ if ($result) {
 					$line->fetch($obj->fdid);
 
 					// Situation invoices handling
-					$prev_progress = $line->get_prev_progress($obj->rowid);
-
+					$prev_progress = $line->getPrevProgressFromInvoiceCycleRefAndType($obj->situation_cycle_ref, $obj->type);
 					$situation_ratio = ($obj->situation_percent - $prev_progress) / $obj->situation_percent;
 				}
 			}

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -6771,6 +6771,7 @@ class FactureLigne extends CommonInvoiceLine
 					dol_syslog(__METHOD__." Error : ".$this->error, LOG_ERR);
 					return -1;
 				}
+
 				return $this->getPrevProgressFromInvoiceCycleRefAndType($invoicecache[$invoiceid]->situation_cycle_ref, $invoicecache[$invoiceid]->type, $include_credit_note);
 			}
 		}
@@ -6795,7 +6796,7 @@ class FactureLigne extends CommonInvoiceLine
 			if ($invoiceType != Facture::TYPE_SITUATION)	return 0;
 
 			$sql1 = "SELECT situation_percent FROM ".$this->db->prefix()."facturedet";
-			$sql1 .= " WHERE rowid=".$this->fk_prev_id;
+			$sql1 .= " WHERE rowid = ".((int) $this->fk_prev_id);
 			$res1 = $this->db->query($sql1);
 			if ($res1) {
 				$error = 0;
@@ -6807,7 +6808,7 @@ class FactureLigne extends CommonInvoiceLine
 					if ($includeCreditNote) {
 						$sql2 = "SELECT fd.situation_percent FROM ".$this->db->prefix()."facturedet fd";
 						$sql2 .= " INNER JOIN ".$this->db->prefix()."facture f ON (f.rowid = fd.fk_facture) ";
-						$sql2 .= " WHERE fd.fk_prev_id = ".$this->fk_prev_id;
+						$sql2 .= " WHERE fd.fk_prev_id = ".((int) $this->fk_prev_id);
 						$sql2 .= " AND f.situation_cycle_ref = ".((int) $invoiceSituationCycleRef); // Prevent cycle outed
 						$sql2 .= " AND f.type = ".Facture::TYPE_CREDIT_NOTE;
 

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -6760,47 +6760,83 @@ class FactureLigne extends CommonInvoiceLine
 		// phpcs:enable
 		global $invoicecache;
 
-		if (is_null($this->fk_prev_id) || empty($this->fk_prev_id) || $this->fk_prev_id == "") {
-			return 0;
-		} else {
+		if ($invoiceid > 0) {
 			// If invoice is not a situation invoice, this->fk_prev_id is used for something else
 			if (!isset($invoicecache[$invoiceid])) {
 				$invoicecache[$invoiceid] = new Facture($this->db);
-				$invoicecache[$invoiceid]->fetch($invoiceid);
+				$result = $invoicecache[$invoiceid]->fetch($invoiceid);
+				if ($result <= 0) {
+					$this->error = $invoicecache[$invoiceid]->errorsToString();
+					$this->errors[] = $this->error;
+					dol_syslog(__METHOD__." Error : ".$this->error, LOG_ERR);
+					return -1;
+				}
+				return $this->getPrevProgressFromInvoiceCycleRefAndType($invoicecache[$invoiceid]->situation_cycle_ref, $invoicecache[$invoiceid]->type, $include_credit_note);
 			}
-			if ($invoicecache[$invoiceid]->type != Facture::TYPE_SITUATION) {
-				return 0;
-			}
+		}
 
-			$sql = "SELECT situation_percent FROM ".MAIN_DB_PREFIX."facturedet WHERE rowid = ".((int) $this->fk_prev_id);
-			$resql = $this->db->query($sql);
-			if ($resql && $this->db->num_rows($resql) > 0) {
-				$res = $this->db->fetch_array($resql);
+		return 0;
+	}
 
-				$returnPercent = floatval($res['situation_percent']);
+	/**
+	 * Returns situation percent of the previous line.
+	 * Warning: If invoice is a replacement invoice, this->fk_prev_id is id of the replaced line.
+	 *
+	 * @param	int		$invoiceSituationCycleRef	Situation cycle reference of invoice
+	 * @param	int		$invoiceType				Type of invoice
+	 * @param	bool	$includeCreditNote			Include credit note or not
+	 * @return	float|int							Return previous situation percent or 0 if not situation invoice or -1 if error
+	 */
+	public function getPrevProgressFromInvoiceCycleRefAndType($invoiceSituationCycleRef, $invoiceType, $includeCreditNote = true)
+	{
+		if (empty($this->fk_prev_id) || $this->fk_prev_id == "") {
+			return 0;
+		} else {
+			if ($invoiceType != Facture::TYPE_SITUATION)	return 0;
 
-				if ($include_credit_note) {
-					$sql = 'SELECT fd.situation_percent FROM '.MAIN_DB_PREFIX.'facturedet fd';
-					$sql .= ' JOIN '.MAIN_DB_PREFIX.'facture f ON (f.rowid = fd.fk_facture) ';
-					$sql .= " WHERE fd.fk_prev_id = ".((int) $this->fk_prev_id);
-					$sql .= " AND f.situation_cycle_ref = ".((int) $invoicecache[$invoiceid]->situation_cycle_ref); // Prevent cycle outed
-					$sql .= " AND f.type = ".Facture::TYPE_CREDIT_NOTE;
+			$sql1 = "SELECT situation_percent FROM ".$this->db->prefix()."facturedet";
+			$sql1 .= " WHERE rowid=".$this->fk_prev_id;
+			$res1 = $this->db->query($sql1);
+			if ($res1) {
+				$error = 0;
+				$returnPercent = 0;
 
-					$res = $this->db->query($sql);
-					if ($res) {
-						while ($obj = $this->db->fetch_object($res)) {
-							$returnPercent = $returnPercent + floatval($obj->situation_percent);
+				if ($obj1 = $this->db->fetch_object($res1)) {
+					$returnPercent = (float) $obj1->situation_percent;
+
+					if ($includeCreditNote) {
+						$sql2 = "SELECT fd.situation_percent FROM ".$this->db->prefix()."facturedet fd";
+						$sql2 .= " INNER JOIN ".$this->db->prefix()."facture f ON (f.rowid = fd.fk_facture) ";
+						$sql2 .= " WHERE fd.fk_prev_id = ".$this->fk_prev_id;
+						$sql2 .= " AND f.situation_cycle_ref = ".((int) $invoiceSituationCycleRef); // Prevent cycle outed
+						$sql2 .= " AND f.type = ".Facture::TYPE_CREDIT_NOTE;
+
+						$res2 = $this->db->query($sql2);
+						if ($res2) {
+							while ($obj2 = $this->db->fetch_object($res2)) {
+								$returnPercent += (float) $obj2->situation_percent;
+							}
+
+							$this->db->free($res2);
+						} else {
+							$error++;
+							$this->error = $this->db->lasterror();
+							$this->errors[] = $this->error;
 						}
-					} else {
-						dol_print_error($this->db);
 					}
 				}
+				$this->db->free($res1);
 
-				return $returnPercent;
+				if ($error) {
+					dol_syslog(__METHOD__." Error : ".$this->error, LOG_ERR);
+					return -1;
+				} else {
+					return $returnPercent;
+				}
 			} else {
-				$this->error = $this->db->error();
-				dol_syslog(get_class($this)."::select Error ".$this->error, LOG_ERR);
-				$this->db->rollback();
+				$this->error = $this->db->lasterror();
+				$this->errors[] = $this->error;
+				dol_syslog(__METHOD__." Error : ".$this->error, LOG_ERR);
 				return -1;
 			}
 		}


### PR DESCRIPTION
Qual - Optimize requests in sells journal for situation invoices
DLB : #30609

- not reload "Facture" object when already loaded from SQL request
- add a method "getPrevProgressFromInvoiceCycleRefAndType" to determine the progress percent from "cycle ref" and invoice "type"

**Remark**
When you got a lot of invoices and you set "INVOICE_USE_SITUATION" to 1, you can excess the max execution time.