### PR TITLE
Fix cdav, ws and api login

### DIFF
--- a/htdocs/api/class/api_login.class.php
+++ b/htdocs/api/class/api_login.class.php
@@ -95,7 +95,7 @@ class Login
 		}
 
 		// Authentication mode
-		if (empty($dolibarr_main_authentication)) {
+		if (empty($dolibarr_main_authentication) || $dolibarr_main_authentication == 'openid_connect') {
 			$dolibarr_main_authentication = 'dolibarr';
 		}
 

--- a/htdocs/core/lib/ws.lib.php
+++ b/htdocs/core/lib/ws.lib.php
@@ -74,7 +74,7 @@ function check_authentication($authentication, &$error, &$errorcode, &$errorlabe
 			$fuser->getrights(); // Load permission of user
 
 			// Authentication mode
-			if (empty($dolibarr_main_authentication)) {
+			if (empty($dolibarr_main_authentication) || $dolibarr_main_authentication == 'openid_connect') {
 				$dolibarr_main_authentication = 'http,dolibarr';
 			}
 			// Authentication mode: forceuser

--- a/htdocs/dav/fileserver.php
+++ b/htdocs/dav/fileserver.php
@@ -109,7 +109,7 @@ $authBackend = new \Sabre\DAV\Auth\Backend\BasicCallBack(function ($username, $p
 	}
 
 	// Authentication mode
-	if (empty($dolibarr_main_authentication)) {
+	if (empty($dolibarr_main_authentication) || $dolibarr_main_authentication == 'openid_connect') {
 		$dolibarr_main_authentication = 'dolibarr';
 	}
 


### PR DESCRIPTION
# Fix #[*#30777*]

Force usage of another authentication when there is only openid_connect since he doesn't work for api, ws, and cdav login