### PR TITLE
Fix php8

### DIFF
--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -259,7 +259,7 @@ if ($action == 'dispatch' && $permissiontoreceive) {
 			}
 
 			// We ask to move a qty
-			if (GETPOST($qty) != 0) {
+			if (!empty(GETPOST($qty)) && GETPOST($qty) != 0) {
 				$productId = GETPOSTINT($prod);
 
 				if (!(GETPOST($ent, 'int') > 0)) {

--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -259,7 +259,7 @@ if ($action == 'dispatch' && $permissiontoreceive) {
 			}
 
 			// We ask to move a qty
-			if (!empty(GETPOST($qty)) && GETPOST($qty) != 0) {
+			if ((float) GETPOST($qty) != 0) {
 				$productId = GETPOSTINT($prod);
 
 				if (!(GETPOST($ent, 'int') > 0)) {


### PR DESCRIPTION
# Fix #[*#30997*]
Fix le fait que depuis PHP 8 une chaine vide n'est plus égale à 0.