### PR TITLE
autofill datef à la création d'un event avec un status set à 100%

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -277,6 +277,9 @@ if (empty($reshook) && $action == 'add') {
 		$datef = dol_mktime(GETPOST("p2hour", 'int'), GETPOST("p2min", 'int'), GETPOST("apsec", 'int'), GETPOST("p2month", 'int'), GETPOST("p2day", 'int'), GETPOST("p2year", 'int'), 'tzuserrel');
 	}
 
+	//set end date to now if percentage is set to 100 and end date not set
+	$datef = (!$datef && $percentage == 100)?dol_now():$datef;
+
 	// Check parameters
 	if (!$datef && $percentage == 100) {
 		$error++; $donotclearsession = 1;


### PR DESCRIPTION
# Fix #[*#31036*]
Fix pour remplir automatiquement la date de fin d'un évènement à sa création si elle n'est pas renseignée et que l'on met au statut terminé