### PR TITLE
Fix champ non proteger ticket publique

### DIFF
--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -210,17 +210,17 @@ if (empty($reshook)) {
 
 		if (!GETPOST("type_code", "alpha")) {
 			$error++;
-			array_push($object->errors, $langs->trans("ErrorFieldRequired", $langs->transnoentities("Subject")));
+			array_push($object->errors, $langs->trans("ErrorFieldRequired", $langs->transnoentities("TicketTypeRequest")));
 			$action = '';
 		}
-		if (!GETPOST("subject", "restricthtml")) {
+		if (!GETPOST("category_code", "alpha")) {
 			$error++;
-			array_push($object->errors, $langs->trans("ErrorFieldRequired", $langs->transnoentities("Subject")));
+			array_push($object->errors, $langs->trans("ErrorFieldRequired", $langs->transnoentities("TicketCategory")));
 			$action = '';
 		}
-		if (!GETPOST("subject", "restricthtml")) {
+		if (!GETPOST("severity_code", "alpha ")) {
 			$error++;
-			array_push($object->errors, $langs->trans("ErrorFieldRequired", $langs->transnoentities("Subject")));
+			array_push($object->errors, $langs->trans("ErrorFieldRequired", $langs->transnoentities("TicketSeverity")));
 			$action = '';
 		}
 		if (!GETPOST("subject", "restricthtml")) {

--- a/htdocs/public/ticket/create_ticket.php
+++ b/htdocs/public/ticket/create_ticket.php
@@ -208,6 +208,21 @@ if (empty($reshook)) {
 			}
 		}
 
+		if (!GETPOST("type_code", "alpha")) {
+			$error++;
+			array_push($object->errors, $langs->trans("ErrorFieldRequired", $langs->transnoentities("Subject")));
+			$action = '';
+		}
+		if (!GETPOST("subject", "restricthtml")) {
+			$error++;
+			array_push($object->errors, $langs->trans("ErrorFieldRequired", $langs->transnoentities("Subject")));
+			$action = '';
+		}
+		if (!GETPOST("subject", "restricthtml")) {
+			$error++;
+			array_push($object->errors, $langs->trans("ErrorFieldRequired", $langs->transnoentities("Subject")));
+			$action = '';
+		}
 		if (!GETPOST("subject", "restricthtml")) {
 			$error++;
 			array_push($object->errors, $langs->trans("ErrorFieldRequired", $langs->transnoentities("Subject")));


### PR DESCRIPTION
# Fix #[*#31042*]
Ce fix est là pour vérifier des champs qui sont requis lors de la création de tickets