### PR TITLE
display event type label instead of event type code if event type cod…

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -1933,9 +1933,10 @@ if ($id > 0) {
 
 		// Type
 		if (!empty($conf->global->AGENDA_USE_EVENT_TYPE)) {
+			$labeltype = ($langs->transnoentities("Action".$object->type_code) != "Action".$object->type_code) ? $langs->transnoentities("Action".$object->type_code) : $object->type_label;
 			print '<tr><td class="titlefield">'.$langs->trans("Type").'</td><td>';
 			print $object->getTypePicto();
-			print $langs->trans("Action".$object->type_code);
+			print $labeltype;
 			print '</td></tr>';
 		}
 

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -808,6 +808,7 @@ class ActionComm extends CommonObject
 				$this->type_color = $obj->type_color;
 				$this->type_picto = $obj->type_picto;
 				$this->type       = $obj->type_type;
+				$this->type_label = $obj->type_label;
 				/*$transcode = $langs->trans("Action".$obj->type_code);
 				$this->type       = (($transcode != "Action".$obj->type_code) ? $transcode : $obj->type_label); */
 				$transcode = (isset($langs) ? $langs->trans("Action".$obj->type_code.'Short') : '');


### PR DESCRIPTION
https://github.com/Dolibarr/dolibarr/pull/31106

Affiche le label de l’événement à la place du code de l’événement si le code n'a pas de traduction. 
