### PR TITLE
Fix a problem when we have an extrafield on the line

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -1715,7 +1715,7 @@ if ($action == 'create') {
 						$line = new ContratLigne($db);
 						$line->id = $objp->rowid;
 						$line->fetch_optionals();
-						print $line->showOptionals($extrafields, 'view', array('class'=>'oddeven', 'style'=>$moreparam, 'colspan'=>$colspan), '', '', 1);
+						print $line->showOptionals($extrafields, 'view', array('class'=>'oddeven', 'style'=>$moreparam, 'colspan'=>$colspan, 'tdclass' => 'notitlefieldcreate'), '', '', 1);
 					}
 				} else {
 					// Line in mode update
@@ -1819,7 +1819,7 @@ if ($action == 'create') {
 						$line = new ContratLigne($db);
 						$line->id = $objp->rowid;
 						$line->fetch_optionals();
-						print $line->showOptionals($extrafields, 'edit', array('style'=>'class="oddeven"', 'colspan'=>$colspan), '', '', 1);
+						print $line->showOptionals($extrafields, 'edit', array('style'=>'class="oddeven"', 'colspan'=>$colspan, 'tdclass' => 'notitlefieldcreate'), '', '', 1);
 					}
 				}
 


### PR DESCRIPTION
# Fix #[*#31104*]
Quand on a un extrafield sur les lignes des contrats, La colonne contenant les labels à sa largeur qui est modifiée par la classe "titlefieldcreate" ajouté par "showOptionals" si "tdclass" est vide ou inexistant parmi les paramètres de la fonction.

Pour éviter que la largeur de la colonne change, j'ajoute une class inexistante pour éviter que "titlefieldcreate" ne sois ajouté.

