### PR TITLE
fix wrong invoice status with discount

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -4534,8 +4534,7 @@ if ($action == 'create') {
 	}
 	$morehtmlref .= '</div>';
 
-	$sumofpaymentall = $totalpaid + $totalcreditnotes + $totaldeposits;
-	$object->totalpaid = $sumofpaymentall; // To give a chance to dol_banner_tab to use already paid amount to show correct status
+	$object->totalpaid = $totalpaid + $totalcreditnotes + $totaldeposits; // To give a chance to dol_banner_tab to use already paid amount to show correct status
 
 	dol_banner_tab($object, 'ref', $linkback, 1, 'ref', 'ref', $morehtmlref, '', 0, '', '');
 

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -4534,7 +4534,8 @@ if ($action == 'create') {
 	}
 	$morehtmlref .= '</div>';
 
-	$object->totalpaid = $totalpaid; // To give a chance to dol_banner_tab to use already paid amount to show correct status
+	$sumofpaymentall = $totalpaid + $totalcreditnotes + $totaldeposits;
+	$object->totalpaid = $sumofpaymentall; // To give a chance to dol_banner_tab to use already paid amount to show correct status
 
 	dol_banner_tab($object, 'ref', $linkback, 1, 'ref', 'ref', $morehtmlref, '', 0, '', '');
 


### PR DESCRIPTION
https://github.com/Dolibarr/dolibarr/pull/31117

Une facture avec une remise reste au statut 'impayée' au lieu de 'réglement commencé'.
Quand on classe la facture en payée partiellement, le statut est fermée (impayée) au lieu de payée partiellement.