### PR TITLE
fix line ref supplier not showing for order supplier

### DIFF
--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -224,6 +224,7 @@ if ($action == 'order' && GETPOST('valid')) {
 						$line->total_ttc = $line->total_ht + $line->total_tva;
 						$line->remise_percent = $productsupplier->remise_percent;
 						$line->ref_supplier = $productsupplier->ref_supplier;
+						$line->ref_fourn = $productsupplier->ref_supplier;
 						$line->product_type = $productsupplier->type;
 						$line->fk_unit = $productsupplier->fk_unit;
 						$suppliers[$productsupplier->fourn_socid]['lines'][] = $line;


### PR DESCRIPTION
Correction pour cette correction : https://github.com/Easya-Solutions/dolibarr/pull/1111/commits/cd2a58395ef4ecac84a1be1a0919095601a8f691

La ref fournisseur ne s'affiche plus pour les commandes créées depuis la page réaprovisionnement.
$line->ref_fourn a été remplacé par $line->ref_supplier. Mais à la création des lignes de commande fournisseur depuis la méthode de création de la commande, $line->ref_fourn est utilisé. 

TS2410-10598