### PR TITLE
FIX missing multidir_output for project sharing (Backport v17 - TS241…

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -2657,7 +2657,7 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 		}
 		$original_file = $conf->commande->multidir_output[$entity].'/'.$original_file;
 		$sqlprotectagainstexternals = "SELECT fk_soc as fk_soc FROM ".MAIN_DB_PREFIX."commande WHERE ref='".$db->escape($refname)."' AND entity IN (".getEntity('order').")";
-	} elseif ($modulepart == 'project' && !empty($conf->projet->dir_output)) {
+	} elseif ($modulepart == 'project' && (!empty($conf->project->multidir_output[$entity]) || !empty($conf->projet->dir_output))) {
 		// Wrapping pour les projets
 		if ($fuser->rights->projet->{$lire} || preg_match('/^specimen/i', $original_file)) {
 			$accessallowed = 1;
@@ -2669,9 +2669,9 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 				$accessallowed = checkUserAccessToObject($user, array('projet'), $tmpproject->id, 'projet&project', '', '', 'rowid', '');
 			}
 		}
-		$original_file = $conf->projet->dir_output.'/'.$original_file;
+		$original_file = (!empty($conf->project->multidir_output[$entity]) ? $conf->project->multidir_output[$entity] : $conf->projet->dir_output).'/'.$original_file;
 		$sqlprotectagainstexternals = "SELECT fk_soc as fk_soc FROM ".MAIN_DB_PREFIX."projet WHERE ref='".$db->escape($refname)."' AND entity IN (".getEntity('project').")";
-	} elseif ($modulepart == 'project_task' && !empty($conf->projet->dir_output)) {
+	} elseif ($modulepart == 'project_task' && (!empty($conf->project->multidir_output[$entity]) || !empty($conf->projet->dir_output))) {
 		if ($fuser->rights->projet->{$lire} || preg_match('/^specimen/i', $original_file)) {
 			$accessallowed = 1;
 			// If we known $id of project, call checkUserAccessToObject to check permission on properties and contact of project
@@ -2682,7 +2682,7 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 				$accessallowed = checkUserAccessToObject($user, array('projet_task'), $tmptask->id, 'projet_task&project', '', '', 'rowid', '');
 			}
 		}
-		$original_file = $conf->projet->dir_output.'/'.$original_file;
+		$original_file = (!empty($conf->project->multidir_output[$entity]) ? $conf->project->multidir_output[$entity] : $conf->projet->dir_output).'/'.$original_file;
 		$sqlprotectagainstexternals = "SELECT fk_soc as fk_soc FROM ".MAIN_DB_PREFIX."projet WHERE ref='".$db->escape($refname)."' AND entity IN (".getEntity('project').")";
 	} elseif (($modulepart == 'commande_fournisseur' || $modulepart == 'order_supplier') && !empty($conf->fournisseur->commande->dir_output)) {
 		// Wrapping pour les commandes fournisseurs

--- a/htdocs/core/lib/project.lib.php
+++ b/htdocs/core/lib/project.lib.php
@@ -274,7 +274,7 @@ function project_prepare_head(Project $project, $moreparam = '')
 	} else {
 		require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 		require_once DOL_DOCUMENT_ROOT.'/core/class/link.class.php';
-		$upload_dir = $conf->projet->dir_output."/".dol_sanitizeFileName($project->ref);
+		$upload_dir = (!empty($conf->project->multidir_output[$project->entity]) ? $conf->project->multidir_output[$project->entity] : $conf->projet->dir_output)."/".dol_sanitizeFileName($project->ref);
 		$nbFiles = count(dol_dir_list($upload_dir, 'files', 0, '', '(\.meta|_preview.*\.png)$'));
 		$nbLinks = Link::count($db, $project->element, $project->id);
 		$totalAttached = $nbFiles + $nbLinks;
@@ -400,7 +400,7 @@ function task_prepare_head($object)
 	}
 
 	$head[$h][0] = DOL_URL_ROOT.'/projet/tasks/document.php?id='.$object->id.(GETPOST('withproject') ? '&withproject=1' : '');
-	$filesdir = $conf->projet->dir_output."/".dol_sanitizeFileName($object->project->ref).'/'.dol_sanitizeFileName($object->ref);
+	$filesdir =  (!empty($conf->project->multidir_output[$object->entity]) ? $conf->project->multidir_output[$object->entity] : $conf->projet->dir_output)."/".dol_sanitizeFileName($object->project->ref).'/'.dol_sanitizeFileName($object->ref);
 	include_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 	include_once DOL_DOCUMENT_ROOT.'/core/class/link.class.php';
 	$nbFiles = count(dol_dir_list($filesdir, 'files', 0, '', '(\.meta|_preview.*\.png)$'));

--- a/htdocs/core/modules/project/doc/pdf_baleine.modules.php
+++ b/htdocs/core/modules/project/doc/pdf_baleine.modules.php
@@ -196,11 +196,11 @@ class pdf_baleine extends ModelePDFProjects
 		// Load traductions files required by page
 		$outputlangs->loadLangs(array("main", "dict", "companies", "projects"));
 
-		if ($conf->projet->dir_output) {
+		if (!empty($conf->project->multidir_output[$object->entity]) || !empty($conf->projet->dir_output)) {
 			//$nblines = count($object->lines);  // This is set later with array of tasks
 
 			$objectref = dol_sanitizeFileName($object->ref);
-			$dir = $conf->projet->dir_output;
+			$dir = (!empty($conf->project->multidir_output[$object->entity]) ? $conf->project->multidir_output[$object->entity] : $conf->projet->dir_output);
 			if (!preg_match('/specimen/i', $objectref)) {
 				$dir .= "/".$objectref;
 			}

--- a/htdocs/core/modules/project/doc/pdf_beluga.modules.php
+++ b/htdocs/core/modules/project/doc/pdf_beluga.modules.php
@@ -235,11 +235,11 @@ class pdf_beluga extends ModelePDFProjects
 		// Load traductions files required by page
 		$outputlangs->loadLangs(array("main", "dict", "companies", "projects"));
 
-		if ($conf->projet->dir_output) {
+		if (!empty($conf->project->multidir_output[$object->entity]) || !empty($conf->projet->dir_output)) {
 			//$nblines = count($object->lines);  // This is set later with array of tasks
 
 			$objectref = dol_sanitizeFileName($object->ref);
-			$dir = $conf->projet->dir_output;
+			$dir = (!empty($conf->project->multidir_output[$object->entity]) ? $conf->project->multidir_output[$object->entity] : $conf->projet->dir_output);
 			if (!preg_match('/specimen/i', $objectref)) {
 				$dir .= "/".$objectref;
 			}

--- a/htdocs/core/modules/project/doc/pdf_timespent.modules.php
+++ b/htdocs/core/modules/project/doc/pdf_timespent.modules.php
@@ -196,11 +196,11 @@ class pdf_timespent extends ModelePDFProjects
 		// Load traductions files required by page
 		$outputlangs->loadLangs(array("main", "dict", "companies", "projects"));
 
-		if ($conf->projet->dir_output) {
+		if (!empty($conf->project->multidir_output[$object->entity]) || !empty($conf->projet->dir_output)) {
 			//$nblines = count($object->lines);  // This is set later with array of tasks
 
 			$objectref = dol_sanitizeFileName($object->ref);
-			$dir = $conf->projet->dir_output;
+			$dir = (!empty($conf->project->multidir_output[$object->entity]) ? $conf->project->multidir_output[$object->entity] : $conf->projet->dir_output);
 			if (!preg_match('/specimen/i', $objectref)) {
 				$dir .= "/".$objectref;
 			}

--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -403,7 +403,7 @@ if (empty($reshook)) {
 			require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 
 			$langs->load("other");
-			$upload_dir = $conf->projet->dir_output;
+			$upload_dir = (!empty($conf->project->multidir_output[$object->entity]) ? $conf->project->multidir_output[$object->entity] : $conf->projet->dir_output);
 			$file = $upload_dir.'/'.GETPOST('file');
 			$ret = dol_delete_file($file, 0, 0, 0, $object);
 			if ($ret) {
@@ -1398,12 +1398,12 @@ if ($action == 'create' && $user->rights->projet->creer) {
 		 * Generated documents
 		 */
 		$filename = dol_sanitizeFileName($object->ref);
-		$filedir = $conf->projet->dir_output."/".dol_sanitizeFileName($object->ref);
+		$filedir = (!empty($conf->project->multidir_output[$object->entity]) ? $conf->project->multidir_output[$object->entity] : $conf->projet->dir_output)."/".dol_sanitizeFileName($object->ref);
 		$urlsource = $_SERVER["PHP_SELF"]."?id=".$object->id;
 		$genallowed = ($user->rights->projet->lire && $userAccess > 0);
 		$delallowed = ($user->rights->projet->creer && $userWrite > 0);
 
-		print $formfile->showdocuments('project', $filename, $filedir, $urlsource, $genallowed, $delallowed, $object->model_pdf);
+		print $formfile->showdocuments('project', $filename, $filedir, $urlsource, $genallowed, $delallowed, $object->model_pdf, 1, 0, 0, 0, 0, '', '', '', '', '', $object);
 
 		print '</div><div class="fichehalfright"><div class="ficheaddleft">';
 
@@ -1424,7 +1424,7 @@ if ($action == 'create' && $user->rights->projet->creer) {
 	// Presend form
 	$modelmail = 'project';
 	$defaulttopic = 'SendProjectRef';
-	$diroutput = $conf->projet->dir_output;
+	$diroutput = (!empty($conf->project->multidir_output[$object->entity]) ? $conf->project->multidir_output[$object->entity] : $conf->projet->dir_output);
 	$autocopy = 'MAIN_MAIL_AUTOCOPY_PROJECT_TO'; // used to know the automatic BCC to add
 	$trackid = 'proj'.$object->id;
 

--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -256,6 +256,7 @@ class Task extends CommonObject
 		$sql = "SELECT";
 		$sql .= " t.rowid,";
 		$sql .= " t.ref,";
+		$sql .= " t.entity,";
 		$sql .= " t.fk_projet as fk_project,";
 		$sql .= " t.fk_task_parent,";
 		$sql .= " t.label,";
@@ -299,6 +300,7 @@ class Task extends CommonObject
 
 				$this->id = $obj->rowid;
 				$this->ref = $obj->ref;
+				$this->entity = $obj->entity;
 				$this->fk_project = $obj->fk_project;
 				$this->fk_task_parent = $obj->fk_task_parent;
 				$this->label = $obj->label;

--- a/htdocs/projet/document.php
+++ b/htdocs/projet/document.php
@@ -48,7 +48,7 @@ if (!empty($conf->global->PROJECT_ALLOW_COMMENT_ON_PROJECT) && method_exists($ob
 }
 
 if ($id > 0 || !empty($ref)) {
-	$upload_dir = $conf->projet->dir_output."/".dol_sanitizeFileName($object->ref);
+	$upload_dir = (!empty($conf->project->multidir_output[$object->entity]) ? $conf->project->multidir_output[$object->entity] : $conf->projet->dir_output)."/".dol_sanitizeFileName($object->ref);
 }
 
 // Get parameters
@@ -107,7 +107,7 @@ llxHeader('', $title, $help_url);
 $form = new Form($db);
 
 if ($object->id > 0) {
-	$upload_dir = $conf->projet->dir_output.'/'.dol_sanitizeFileName($object->ref);
+	$upload_dir = (!empty($conf->project->multidir_output[$object->entity]) ? $conf->project->multidir_output[$object->entity] : $conf->projet->dir_output).'/'.dol_sanitizeFileName($object->ref);
 
 	// To verify role of users
 	//$userAccess = $object->restrictedProjectArea($user,'read');

--- a/htdocs/projet/tasks/document.php
+++ b/htdocs/projet/tasks/document.php
@@ -109,7 +109,7 @@ if ($id > 0 || !empty($ref)) {
 
 	$object->project = clone $projectstatic;
 
-	$upload_dir = $conf->projet->dir_output.'/'.dol_sanitizeFileName($projectstatic->ref).'/'.dol_sanitizeFileName($object->ref);
+	$upload_dir = (!empty($conf->project->multidir_output[$projectstatic->entity]) ? $conf->project->multidir_output[$projectstatic->entity] : $conf->projet->dir_output).'/'.dol_sanitizeFileName($projectstatic->ref).'/'.dol_sanitizeFileName($object->ref);
 }
 
 include DOL_DOCUMENT_ROOT.'/core/actions_linkedfiles.inc.php';


### PR DESCRIPTION
FIX missing multidir_output for project sharing (Backport v17 - TS2410-10593)

Backport of commit : https://github.com/Dolibarr/dolibarr/commit/7a12ba9c2006e6680575a4ff40e0ecf8a7fbdbb2

**Remarque** : Reprise du commit car il n'y a pas la conservation de la compatibilité si on a pas le multi-entité et peut engendrer des warnings avec PHP 8.2

_Est-ce qu'il ne faudrait pas proposer aussi un correctif sur la branche 18.0 et le reporter sur Easya 2024 ?_