### PR TITLE
CORE mail: Fix return value of hook sendMail when hook return -1 who must be return false in sendfile() function

### DIFF
--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -687,7 +687,7 @@ class CMailFile
 				$this->error = "Error in hook maildao sendMail ".$reshook;
 				dol_syslog("CMailFile::sendfile: mail end error=".$this->error, LOG_ERR);
 
-				return $reshook;
+				return false;
 			}
 			if ($reshook == 1) {	// Hook replace standard code
 				return true;


### PR DESCRIPTION
Fix return value of hook sendMail when hook return -1 who must be return false in sendfile() function PR #31460
