### PR TITLE
FIX send mail to BCC when email formated as Fullname <email>

### DIFF
--- a/htdocs/core/actions_sendmails.inc.php
+++ b/htdocs/core/actions_sendmails.inc.php
@@ -310,7 +310,7 @@ if (($action == 'send' || $action == 'relance') && !GETPOST('addfile') && !GETPO
 			// <img alt="" src="'.$urlwithroot.'viewimage.php?modulepart=medias&amp;entity=1&amp;file=image/ldestailleur_166x166.jpg" style="height:166px; width:166px" />
 			$message = preg_replace('/(<img.*src=")[^\"]*viewimage\.php([^\"]*)modulepart=medias([^\"]*)file=([^\"]*)("[^\/]*\/>)/', '\1'.$urlwithroot.'/viewimage.php\2modulepart=medias\3file=\4\5', $message);
 
-			$sendtobcc = GETPOST('sendtoccc');
+			$sendtobcc = GETPOST('sendtoccc', 'alphawithlgt');
 			// Autocomplete the $sendtobcc
 			// $autocopy can be MAIN_MAIL_AUTOCOPY_PROPOSAL_TO, MAIN_MAIL_AUTOCOPY_ORDER_TO, MAIN_MAIL_AUTOCOPY_INVOICE_TO, MAIN_MAIL_AUTOCOPY_SUPPLIER_PROPOSAL_TO...
 			if (!empty($autocopy)) {


### PR DESCRIPTION
FIX send mail to BCC when email formatted as Fullname with email
DLB : https://github.com/Dolibarr/dolibarr/pull/31983
- in all recipients (to, cc, bcc) from form field you can have email or fullname with email

When you got "Fullname with email" in the BCC field, you got this error : 
**Error [120]: Ran into problems sending Mail. Response: 501 5.5.4 Invalid TO: Missing '>' at end of path**

In this case the GETPOST("sendtoccc") removed the "email" posted value and only the "Fullname" remained.
So we got a wrong "email" format sent.

I used GETPOST("sendtoccc", "alphawithlgt") such as it was already applied for others recipients fields (To and CC).
