### PR TITLE
NEW hook getNomUrl in supplier order object and show tooltip on reference of linked objects (Backport v16 and v17)

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -795,7 +795,7 @@ class CommandeFournisseur extends CommonOrder
 	 */
 	public function getNomUrl($withpicto = 0, $option = '', $notooltip = 0, $save_lastsearch_value = -1, $addlinktonotes = 0)
 	{
-		global $langs, $conf, $user;
+		global $langs, $conf, $user, $hookmanager;;
 
 		$result = '';
 
@@ -877,6 +877,15 @@ class CommandeFournisseur extends CommonOrder
 			}
 		}
 
+		global $action;
+		$hookmanager->initHooks(array($this->element . 'dao'));
+		$parameters = array('id'=>$this->id, 'getnomurl' => &$result);
+		$reshook = $hookmanager->executeHooks('getNomUrl', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+		if ($reshook > 0) {
+			$result = $hookmanager->resPrint;
+		} else {
+			$result .= $hookmanager->resPrint;
+		}
 		return $result;
 	}
 

--- a/htdocs/fourn/commande/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/fourn/commande/tpl/linkedobjectblock.tpl.php
@@ -46,7 +46,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	?>
 	<tr class="<?php echo $trclass; ?>">
 		<td><?php echo $langs->trans("SupplierOrder"); ?></td>
-		<td><a href="<?php echo DOL_URL_ROOT.'/fourn/commande/card.php?id='.$objectlink->id ?>"><?php echo img_object($langs->trans("ShowOrder"), "order").' '.$objectlink->ref; ?></a></td>
+		<td><?php print $objectlink->getNomUrl(1); ?></td>
 		<td class="left"><?php echo $objectlink->ref_supplier; ?></td>
 		<td class="center"><?php echo dol_print_date($objectlink->date, 'day'); ?></td>
 		<td class="right"><?php


### PR DESCRIPTION
NEW hook getNomUrl in supplier order object and show tooltip on reference of linked objects (Backport v16 and v17)
- commit : https://github.com/Dolibarr/dolibarr/commit/11fc0da398b29bd2ce80e91957c6566f7ed8d1f6
- and commit : https://github.com/Dolibarr/dolibarr/commit/e4c5fee8df10824a36e9fc71c7bfe7dfc4f41e9c