### PR TITLE
 NEW : ODT {object_type_label} for Invoices and Supplier Invoices

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -572,6 +572,14 @@ abstract class CommonDocGenerator
 			$resarray[$array_key.'_total_discount_ht'] = '';
 		}
 
+		if ($object->element == 'facture' || $object->element == 'invoice_supplier') {
+			if ($object->type == 0) {
+			$resarray[$array_key.'_type_label'] = $outputlangs->transnoentities("PdfInvoiceTitle");
+			} else {
+			$resarray[$array_key.'_type_label'] = (empty($object)) ? '' : $object->getLibType(0);
+			}
+		}
+
 		// Fetch project information if there is a project assigned to this object
 		if ($object->element != "project" && !empty($object->fk_project) && $object->fk_project > 0) {
 			if (!is_object($object->project)) {


### PR DESCRIPTION
New substitution for ODT files for customer/supplier invoice.

On native PDFs (sponge/cannelle), the invoice type is displayed. This does not exist on ODT files.

This PR introduces a new substitution {object_type_label} that displays the translated type of invoice.

https://github.com/Dolibarr/dolibarr/pull/32394