### PR TITLE
FIX logged user as global user for hooks in external modules (WebPortal)

### DIFF
--- a/htdocs/public/webportal/webportal.main.inc.php
+++ b/htdocs/public/webportal/webportal.main.inc.php
@@ -284,7 +284,12 @@ if (!defined('WEBPORTAL_NOLOGIN') && !empty($context->controllerInstance->access
 						$context->logged_user = $logged_user;
 						$context->logged_thirdparty = $logged_thirdparty;
 						$context->logged_member = $logged_member;
-						$context->logged_partnership = $logged_partnership;
+						if (!empty($logged_partnership)) {
+							$context->logged_partnership = $logged_partnership;
+						}
+
+						global $user; // set global user as logged user (used for hooks in external modules)
+						$user = $context->logged_user;
 					}
 				}
 			}


### PR DESCRIPTION
FIX logged user as global user for hooks in external modules (WebPortal)
- DLB : #32511
- set global user for using in hooks of external modules
- fix warning on undefined "logged_partnership"