### PR TITLE
Allow to delete an invoice if it is a deposit and FACTURE_DEPOSITS_ARE_JUST_PAYMENTS

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -461,6 +461,10 @@ abstract class CommonInvoice extends CommonObject
 			return 0;
 		}
 
+		if ($this->type == self::TYPE_DEPOSIT && !empty($conf->global->FACTURE_DEPOSITS_ARE_JUST_PAYMENTS)) {
+            return 1;
+        }
+
 		// If not a draft invoice and not temporary invoice
 		if ($tmppart !== 'PROV') {
 			$ventilExportCompta = $this->getVentilExportCompta();


### PR DESCRIPTION
Autorise à supprimer une facture d'avoir validée si FACTURE_DEPOSITS_ARE_JUST_PAYMENTS est set.

Nécessaire pour la migration d'un client.

Je pense que Eldy n'acceptera pas cette PR.