### PR TITLE
Fix default checkbox extrafields

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8350,6 +8350,13 @@ abstract class CommonObject
 							}
 						}
 
+						if (in_array($extrafields->attributes[$this->table_element]['type'][$key], array('checkbox'))) {
+							if ($action == 'create') {
+								$value = (GETPOSTISSET($keyprefix.'options_'.$key.$keysuffix) || $value) ? $value : explode(',',$extrafields->attributes[$this->table_element]['default'][$key]);
+							}
+						}
+
+
 						$labeltoshow = $langs->trans($label);
 						$helptoshow = $langs->trans($extrafields->attributes[$this->table_element]['help'][$key]);
 


### PR DESCRIPTION
https://github.com/Dolibarr/dolibarr/pull/32813

# FIX : allow default value using checkbox extrafields

When using a checkbox extrafield, one have the ability to set default value(s) : 

![image](https://github.com/user-attachments/assets/736f10e2-6621-4c63-92d3-d5024ab5ebdb)

However, when going to the create form, the default values are not used : 
![image](https://github.com/user-attachments/assets/fd344c62-b722-4fad-8222-4c7df63f1a90)

This PR fixes this behavior and allows defaults values separated by a comma.