### PR TITLE
backport fix for lang of payment page

### DIFF
--- a/htdocs/public/payment/newpayment.php
+++ b/htdocs/public/payment/newpayment.php
@@ -73,7 +73,7 @@ $hookmanager->initHooks(array('newpayment'));
 
 // Load translation files
 // Use browser-defined language
-$langs->setDefaultLang('auto');
+// $langs->setDefaultLang('auto'); // EASYA : backport from develop, where this line is absent.
 $langs->loadLangs(array("main", "other", "dict", "bills", "companies", "errors", "paybox", "paypal", "stripe")); // File with generic data
 
 // Security check

--- a/htdocs/public/payment/paymentko.php
+++ b/htdocs/public/payment/paymentko.php
@@ -57,7 +57,7 @@ if (isModEnabled('paypal')) {
 }
 
 // Use browser-defined language
-$langs->setDefaultLang('auto');
+// $langs->setDefaultLang('auto'); // EASYA : backport from develop, where this line is absent.
 $langs->loadLangs(array("main", "other", "dict", "bills", "companies", "paybox", "paypal", "stripe"));
 
 if (isModEnabled('paypal')) {

--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -65,7 +65,7 @@ $hookmanager = new HookManager($db);
 $hookmanager->initHooks(array('newpayment'));
 
 // Use browser-defined language
-$langs->setDefaultLang('auto');
+// $langs->setDefaultLang('auto'); // EASYA : backport from develop, where this line is absent.
 $langs->loadLangs(array("main", "other", "dict", "bills", "companies", "paybox", "paypal"));
 
 // Clean parameters


### PR DESCRIPTION
Sur les pages de paiements, la langue est mal gérée, les traductions sont partielles.
Ceci est corrigé par un backport depuis develop : les lignes de chargement de la langue par défaut sont absentes. Dolibarr utilise la langue demandée par le navigateur.