### PR TITLE
CORE invoice: Backport and fix - If the global INVOICE_CAN_NEVER_BE_EDITED disabled the action 'modify' of a invoice, we test in the point of entry of the action and not after we make many useless tests

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -730,7 +730,7 @@ if (empty($reshook)) {
 				}
 			}
 		}
-	} elseif ($action == 'confirm_modif' && $usercanunvalidate) {
+	} elseif ($action == 'confirm_modif' && $usercanunvalidate && !getDolGlobalString('INVOICE_CAN_NEVER_BE_EDITED')) {
 		// Go back to draft status (unvalidate)
 		$idwarehouse = GETPOST('idwarehouse', 'int');
 
@@ -4259,6 +4259,10 @@ if ($action == 'create') {
 		}
 
 		$text = $langs->trans('ConfirmValidateBill', $numref);
+		if (getDolGlobalString('INVOICE_CAN_NEVER_BE_EDITED')) {
+			$text .= '<br><br>';
+			$text .= img_picto('', 'warning', 'class="pictofixedwidth"').' '.$langs->trans('WarningInvoiceCanNeverBeEdited');
+		}
 		if (isModEnabled('notification')) {
 			require_once DOL_DOCUMENT_ROOT.'/core/class/notify.class.php';
 			$notify = new Notify($db);
@@ -4316,7 +4320,7 @@ if ($action == 'create') {
 		if ($nbMandated > 0 ) $text .= '<div><span class="clearboth nowraponall warning">'.$langs->trans("mandatoryPeriodNeedTobeSetMsgValidate").'</span></div>';
 
 
-		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?facid='.$object->id, $langs->trans('ValidateBill'), $text, 'confirm_valid', $formquestion, (($object->type != Facture::TYPE_CREDIT_NOTE && $object->total_ttc < 0) ? "no" : "yes"), 2);
+		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?facid='.$object->id, $langs->trans('ValidateBill'), $text, 'confirm_valid', $formquestion, (($object->type != Facture::TYPE_CREDIT_NOTE && $object->total_ttc < 0) ? "no" : "yes"), 2, 260);
 	}
 
 	// Confirm back to draft status
@@ -5650,7 +5654,7 @@ if ($action == 'create') {
 				)
 			);
 			// Editer une facture deja validee, sans paiement effectue et pas exporte en compta
-			if ($object->statut == Facture::STATUS_VALIDATED) {
+			if ($object->statut == Facture::STATUS_VALIDATED && !getDolGlobalString('INVOICE_CAN_NEVER_BE_EDITED')) {
 				// We check if lines of invoice are not already transfered into accountancy
 				$ventilExportCompta = $object->getVentilExportCompta();
 

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -380,6 +380,7 @@ RelatedCustomerInvoices=Related customer invoices
 RelatedSupplierInvoices=Related vendor invoices
 LatestRelatedBill=Latest related invoice
 WarningBillExist=Warning, one or more invoices already exist
+WarningInvoiceCanNeverBeEdited=Warning, once validated, you will no longer be able to modify this invoice
 MergingPDFTool=Merging PDF tool
 AmountPaymentDistributedOnInvoice=Payment amount distributed on invoice
 PaymentOnDifferentThirdBills=Allow payments on different third parties bills but same parent company

--- a/htdocs/langs/fr_FR/bills.lang
+++ b/htdocs/langs/fr_FR/bills.lang
@@ -381,6 +381,7 @@ RelatedCustomerInvoices=Factures clients liées
 RelatedSupplierInvoices=Factures fournisseurs liées
 LatestRelatedBill=Dernière facture en rapport
 WarningBillExist=Attention, une ou plusieurs factures existent déjà
+WarningInvoiceCanNeverBeEdited=Attention, une fois validé, vous ne pourrez plus editer cette facture
 MergingPDFTool=Outil de fusion de PDF
 AmountPaymentDistributedOnInvoice=Montant paiement affecté à la facture
 PaymentOnDifferentThirdBills=Autoriser le règlement de factures de différents tiers si ils ont la même maison-mère


### PR DESCRIPTION
Backport
And fix (If the global INVOICE_CAN_NEVER_BE_EDITED disabled the action 'modify' of a invoice, we test in the point of entry of the action and not after we make many useless tests PR #33594 )