### PR TITLE
Fix : on update of an order line, the TTC price would be used as HT price

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3281,7 +3281,7 @@ class Commande extends CommonOrder
 			$this->line->localtax1_type = empty($localtaxes_type[0]) ? '' : $localtaxes_type[0];
 			$this->line->localtax2_type = empty($localtaxes_type[2]) ? '' : $localtaxes_type[2];
 			$this->line->remise_percent = $remise_percent;
-			$this->line->subprice       = $subprice;
+			$this->line->subprice       = $pu_ht;
 			$this->line->info_bits      = $info_bits;
 			$this->line->special_code   = $special_code;
 			$this->line->total_ht       = $total_ht;


### PR DESCRIPTION
# FIX When editing an order line, the TTC price would be used as HT price

https://github.com/Dolibarr/dolibarr/pull/33940

demonstration :
![TTC_V18](https://github.com/user-attachments/assets/21ba735c-6108-4fe4-83cc-9936094157d8)

This has already been fixed on 19.0, but not on 18.0

