### PR TITLE
Draft : FIX update bookkeeping element date - multicurrency 

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -1455,6 +1455,7 @@ class BookKeeping extends CommonObject
 	 */
 	public function updateByMvt($piece_num = '', $field = '', $value = '', $mode = '')
 	{
+		global $conf;
 		$error = 0;
 
 		$sql_filter = $this->getCanModifyBookkeepingSQL();
@@ -1467,6 +1468,7 @@ class BookKeeping extends CommonObject
 		$sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element.$mode;
 		$sql .= " SET ".$field." = ".(is_numeric($value) ? ((float) $value) : "'".$this->db->escape($value)."'");
 		$sql .= " WHERE piece_num = ".((int) $piece_num);
+		$sql .= " AND entity = " . ((int) $conf->entity);
 		$sql .= $sql_filter;
 
 		$resql = $this->db->query($sql);


### PR DESCRIPTION
# FIX update bookkeeping element date - multicurrency 

#34226

This bug occurs when multicurrency module is activated and there are many entities with accountancy module activated.

When updating the date of a bookkeeping element(page accountancy/bookkeeping/card.php), if another element has the same `piece_num` in other entities, both elements are updated.

This PR fixes this behavior.
