### PR TITLE
FIX: Fix natural search with negative numbers

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -10480,7 +10480,7 @@ function natural_search($fields, $value, $mode = 0, $nofirstand = 0)
 				}
 				$i2++; // a criteria for 1 more field was added to string
 			} elseif ($mode == 2 || $mode == -2) {
-				$crit = preg_replace('/[^0-9,]/', '', $crit); // ID are always integer
+				$crit = preg_replace('/[^\-0-9,]/', '', $crit); // ID are always integer
 				$newres .= ($i2 > 0 ? ' OR ' : '').$field." ".($mode == -2 ? 'NOT ' : '');
 				$newres .= $crit ? "IN (".$db->sanitize($db->escape($crit)).")" : "IN (0)";
 				if ($mode == -2) {


### PR DESCRIPTION
PR #34322

Case when filter prospect status on company list with "not to be contacted" (who has as value -1) selected (it's transformed to 1 (who is "contacted") )

![image](https://github.com/user-attachments/assets/a422c6c3-0082-4be5-bcc1-77b2ba61ae1b)
