### PR TITLE
FIX odt models of bom and mo modules (TS2506-11987)

### DIFF
--- a/htdocs/core/modules/bom/doc/doc_generic_bom_odt.modules.php
+++ b/htdocs/core/modules/bom/doc/doc_generic_bom_odt.modules.php
@@ -396,7 +396,7 @@ class doc_generic_bom_odt extends ModelePDFBom
 				$foundtagforlines = 1;
 				try {
 					$listlines = $odfHandler->setSegment('lines');
-				} catch (OdfExceptionSegmentNotFound $e) {
+				} catch (OdfException $e) {
 					// We may arrive here if tags for lines not present into template
 					$foundtagforlines = 0;
 					dol_syslog($e->getMessage(), LOG_INFO);

--- a/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
+++ b/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
@@ -395,7 +395,7 @@ class doc_generic_mo_odt extends ModelePDFMo
 				$foundtagforlines = 1;
 				try {
 					$listlines = $odfHandler->setSegment('lines');
-				} catch (OdfExceptionSegmentNotFound $e) {
+				} catch (OdfException $e) {
 					// We may arrive here if tags for lines not present into template
 					$foundtagforlines = 0;
 					dol_syslog($e->getMessage(), LOG_INFO);


### PR DESCRIPTION
FIX odt models of bom and mo modules (TS2506-11987)
- backport from v21 (BOM and MRP module) -> Easya only