### PR TITLE
CORE commanobject : Add property 'donthavefksoc' on CommonObject

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -119,6 +119,12 @@ abstract class CommonObject
 	public $ismultientitymanaged;
 
 	/**
+	 * @var int<0,1>		  	Does this object dont have a link to societe with fk_soc ?
+	 * 							0=No, 1=Yes
+	 */
+	public $donthavefksoc;
+
+	/**
 	 * @var string		Key value used to track if data is coming from import wizard
 	 */
 	public $import_key;

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -8142,7 +8142,7 @@ class Form
 				if ($objecttmp->ismultientitymanaged == 1 && !empty($user->socid)) {
 					if ($objecttmp->element == 'societe') {
 						$sql .= " AND t.rowid = " . ((int) $user->socid);
-					} else {
+					} elseif (empty($objecttmp->donthavefksoc)) {
 						$sql .= " AND t.fk_soc = " . ((int) $user->socid);
 					}
 				}


### PR DESCRIPTION
Add property 'donthavefksoc' on CommonObject class for manage the case of a fields of type 'link' to a class who dont have a field fk_soc when the multi entity is activated and we connect with a external user (when the function selectForFormsList() is used for display the select input on list and card)

PR #34643
