### PR TITLE
 Fixed the display order of product/service images.

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8731,7 +8731,7 @@ abstract class CommonObject
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/images.lib.php';
 
-		$sortfield = 'position_name';
+		$sortfield = 'position';
 		$sortorder = 'asc';
 
 		$dir = $sdir.'/';

--- a/htdocs/product/document.php
+++ b/htdocs/product/document.php
@@ -76,7 +76,7 @@ if (!$sortorder) {
 	$sortorder = "ASC";
 }
 if (!$sortfield) {
-	$sortfield = "position_name";
+	$sortfield = "position";
 }
 
 // Initialize objects


### PR DESCRIPTION
#34825
The name of the sorting field does not exist!

Pull Request Overview (from copilot)
This PR fixes an incorrect sorting field name that was preventing proper display order of product/service images. The change corrects a non-existent field reference that was causing sorting issues.

Changed sorting field from "position_name" to "position" in two locations Fixed the default sort field for product document listing Corrected the sort field in the photo display functionality