### PR TITLE
CORE actioncom: Fix substitutions sur l'envoi de l'email de rappel des evenements

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -2535,6 +2535,7 @@ class ActionComm extends CommonObject
 
 						//Topic
 						$sendTopic = (!empty($arraymessage->topic)) ? $arraymessage->topic : html_entity_decode($langs->transnoentities('EventReminder'));
+						$sendTopic = make_substitutions($sendTopic, $substitutionarray);
 
 						// Recipient
 						$recipient = new User($this->db);


### PR DESCRIPTION
Fix substitutions sur l'envoi de l'email de rappel des evenements PR #35621
