### PR TITLE
FIX day of ticket on takePOS. Backport 6abdb6e.

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -490,8 +490,14 @@ if (empty($reshook)) {
 	if (($action == "addline" || $action == "freezone") && $placeid == 0) {
 		$invoice->socid = getDolGlobalString($constforcompanyid);
 
-		include_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
-		$invoice->date = dol_get_first_hour(dol_now('tzuserrel'));		// Invoice::create() needs a date with no hours
+		$dolnowtzuserrel = dol_now('tzuserrel');	// If user is 02 january 22:00, we want to store '02 january'
+		$monthuser = dol_print_date($dolnowtzuserrel, '%m', 'gmt');
+		$dayuser = dol_print_date($dolnowtzuserrel, '%d', 'gmt');
+		$yearuser = dol_print_date($dolnowtzuserrel, '%Y', 'gmt');
+		$dateinvoice = dol_mktime(0, 0, 0, (int) $monthuser, (int) $dayuser, (int) $yearuser, 'tzserver');	// If we enter the 02 january, we need to save the 02 january for server
+
+		// include_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
+		$invoice->date = $dateinvoice;		// Invoice::create() needs a date with no hours
 
 		$invoice->module_source = 'takepos';
 		$invoice->pos_source =  isset($_SESSION["takeposterminal"]) ? $_SESSION["takeposterminal"] : '' ;


### PR DESCRIPTION

# FIX wrong date on takepos invoices 

Case : user is in GMT+2. 
If an invoice is created from TakePOS after 22:00:00, the fields `datef` will be set to next day.

This is a backport of 6abdb6e.



