### PR TITLE
FIX remove situation invoice from cycle when it is canceled by a credit

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5191,9 +5191,9 @@ if ($action == 'create') {
 			$total_next_ht = $total_next_ttc = 0;
 
 			foreach ($object->tab_next_situation_invoice as $next_invoice) {
-				$totalpaid = $next_invoice->getSommePaiement(0);
-				$totalcreditnotes = $next_invoice->getSumCreditNotesUsed(0);
-				$totaldeposits = $next_invoice->getSumDepositsUsed(0);
+				$next_invoice_total_paid = $next_invoice->getSommePaiement(0);
+				$next_invoice_totalcreditnotes = $next_invoice->getSumCreditNotesUsed(0);
+				$next_invoice_totaldeposits = $next_invoice->getSumDepositsUsed(0);
 				$total_next_ht += $next_invoice->total_ht;
 				$total_next_ttc += $next_invoice->total_ttc;
 
@@ -5206,7 +5206,7 @@ if ($action == 'create') {
 				}
 				print '<td class="right"><span class="amount">'.price($next_invoice->total_ht).'</span></td>';
 				print '<td class="right"><span class="amount">'.price($next_invoice->total_ttc).'</span></td>';
-				print '<td class="right">'.$next_invoice->getLibStatut(3, $totalpaid + $totalcreditnotes + $totaldeposits).'</td>';
+				print '<td class="right">'.$next_invoice->getLibStatut(3, $next_invoice_total_paid + $next_invoice_totalcreditnotes + $next_invoice_totaldeposits).'</td>';
 				print '</tr>';
 			}
 


### PR DESCRIPTION
PR DLB https://github.com/Dolibarr/dolibarr/pull/35812


# FIX #35811: you can't remove a situation from cycle even if available credit "pays" for the invoice

The bug is due to the fact that `$totalcreditnotes` is set at line 4784 and used at line 6714 :

```php
// l.4784
$totalcreditnotes = $object->getSumCreditNotesUsed();

// l.6714
if (($object->total_ttc - $totalcreditnotes) == 0) {
```

But inbetween, we have a loop on next invoices in cycle that effectively overrides the value of `$totalcreditnotes` and sets it to `null`: 

```php
//l.5957
				foreach ($object->tab_next_situation_invoice as $next_invoice) {
					$totalpaid = $next_invoice->getSommePaiement(0);
					$totalcreditnotes = $next_invoice->getSumCreditNotesUsed(0);
```

