### PR TITLE
FIX not remove value of others extra-fields on update extras action

### DIFF
--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -357,9 +357,11 @@ if (preg_match('/^set(\w+)$/', $action, $reg) && GETPOST('id', 'int') > 0 && !em
 if ($action == "update_extras" && GETPOST('id', 'int') > 0 && !empty($permissiontoadd)) {
 	$object->fetch(GETPOST('id', 'int'));
 
+	$attribute = GETPOST('attribute', 'aZ09');
+
 	$error = 0;
 
-	$ret = $extrafields->setOptionalsFromPost(null, $object, '@GETPOSTISSET');
+	$ret = $extrafields->setOptionalsFromPost(null, $object, $attribute);
 	if ($ret < 0) {
 		$error++;
 		setEventMessages($extrafields->error, $object->errors, 'errors');


### PR DESCRIPTION
FIX not reset values of others extra-fields on updating only one extra-field : 
- DLB #36491