### PR TITLE
invert colors when MAIN_MENU_INVERT is set

### DIFF
--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -164,8 +164,8 @@ $borderradius = getDolGlobalString('THEME_ELDY_USEBORDERONTABLE') ? getDolGlobal
 /* ============================================================================== */
 
 :root {
-	--colorbackhmenu1: rgb(<?php print $colorbackhmenu1; ?>);
-	--colorbackvmenu1: rgb(<?php print $colorbackvmenu1; ?>);
+	--colorbackhmenu1: rgb(<?php print (getDolGlobalInt('MAIN_MENU_INVERT') ? $colorbackvmenu1 : $colorbackhmenu1); ?>);
+	--colorbackvmenu1: rgb(<?php print (getDolGlobalInt('MAIN_MENU_INVERT') ? $colorbackhmenu1 : $colorbackvmenu1); ?>);
 	--colorbacktitle1: rgb(<?php print $colorbacktitle1; ?>);
 	--colorbacktabcard1: rgb(<?php print $colorbacktabcard1; ?>);
 	--colorbacktabactive: rgb(<?php print $colorbacktabactive; ?>);
@@ -3523,7 +3523,7 @@ div.login_block {
 	<?php } ?>
 }
 div.login_block a {
-	color: var(--colortextbackhmenu);
+	color: var(<?php print (getDolGlobalInt('MAIN_MENU_INVERT') ? '--colortextbackvmenu' : '--colortextbackhmenu') ?>);
 	display: inline-block;
 }
 div.login_block a .atoploginusername {
@@ -3533,7 +3533,7 @@ div.login_block a .atoploginusername {
 	text-overflow: ellipsis;
 }
 div.login_block span.aversion {
-	color: var(--colortextbackhmenu);
+	color: var(<?php print (getDolGlobalInt('MAIN_MENU_INVERT') ? '--colortextbackvmenu' : '--colortextbackhmenu') ?>) !important;
 	filter: contrast(0.7);
 }
 div.login_block table {
@@ -3586,7 +3586,7 @@ div.login_block_user {
 	height: 25px;
 }
 .atoplogin, .atoplogin:hover {
-	color: var(--colortextbackhmenu) !important;
+	color: var(<?php print (getDolGlobalInt('MAIN_MENU_INVERT') ? '--colortextbackvmenu' : '--colortextbackhmenu') ?>) !important;
 }
 .login_block_getinfo {
 	text-align: center;

--- a/htdocs/theme/eldy/style.css.php
+++ b/htdocs/theme/eldy/style.css.php
@@ -218,6 +218,11 @@ if (!isset($conf->global->THEME_ELDY_TOPMENU_BACK1)) {
 if (!isset($conf->global->THEME_ELDY_VERMENU_BACK1)) {
 	$conf->global->THEME_ELDY_VERMENU_BACK1 = $colorbackvmenu1;
 }
+if (getDolGlobalInt('MAIN_MENU_INVERT')) {
+	$save_THEME_ELDY_TOPMENU_BACK1 = getDolGlobalString('THEME_ELDY_TOPMENU_BACK1');
+	$conf->global->THEME_ELDY_TOPMENU_BACK1 = getDolGlobalString('THEME_ELDY_VERMENU_BACK1');
+	$conf->global->THEME_ELDY_VERMENU_BACK1 = $save_THEME_ELDY_TOPMENU_BACK1;
+}
 if (!isset($conf->global->THEME_ELDY_BACKTITLE1)) {
 	$conf->global->THEME_ELDY_BACKTITLE1 = $colorbacktitle1;
 }


### PR DESCRIPTION
# FIX MAIN_MENU_INVERT colors


Inverstion des couleurs de texte des menus lorsque MAIN_MENU_INVERT est set : 

TODO : proposer dans DLB. J'attends le retour de RD.  22_fix_main_menu_invert_colors to port to DLB

avant
<img width="911" height="1151" alt="image" src="https://github.com/user-attachments/assets/98b6136c-f1e5-4715-a230-f8522e40a6a5" />


après
<img width="673" height="1138" alt="image" src="https://github.com/user-attachments/assets/a6294079-13ca-4c5d-bf21-7c3988f05b0e" />

avec nouveau module easya

<img width="985" height="591" alt="image" src="https://github.com/user-attachments/assets/5871bcef-80bb-42f0-b892-33d860001687" />




